### PR TITLE
fixed: error is thrown while creating config file if the parent directory is missing

### DIFF
--- a/semi/config/commands.py
+++ b/semi/config/commands.py
@@ -76,6 +76,7 @@ class Configuration:
             self.config_path = Path(os.path.join(os.getenv("HOME"),
                                             self.default_file_path,
                                             self.default_file_name))
+            self.config_path.parent.mkdir(parents=True, exist_ok=True)
             self.config_path.touch(exist_ok=True)
             with open(self.config_path, 'r', encoding="utf-8") as configuration_file:
                 try:

--- a/semi/version.py
+++ b/semi/version.py
@@ -2,4 +2,4 @@
 The Weaviate CLI version.
 """
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"


### PR DESCRIPTION
will fix https://github.com/weaviate/weaviate-cli/issues/64
fixed a bug where error is thrown while creating config file if the parent directory is not present.
