### PR TITLE
Add defaults class and rename ingest_data.

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -22,7 +22,6 @@ def print_version(ctx, param, value):
 @click.option(
     "--config-file",
     required=False,
-    default=None,
     type=str,
     is_flag=False,
     help="If specified cli uses the config specified with this path.",

--- a/test/unittests/test_defaults.py
+++ b/test/unittests/test_defaults.py
@@ -1,0 +1,417 @@
+import pytest
+from weaviate_cli.defaults import *
+from weaviate.collections.classes.tenants import TenantActivityStatus
+from weaviate_cli.commands.create import (
+    create_collection_cli,
+    create_tenants_cli,
+    create_backup_cli,
+    create_data_cli,
+)
+from weaviate_cli.commands.delete import (
+    delete_collection_cli,
+    delete_tenants_cli,
+    delete_data_cli,
+)
+from weaviate_cli.commands.get import (
+    get_collection_cli,
+    get_tenants_cli,
+    get_shards_cli,
+    get_backup_cli,
+)
+from weaviate_cli.commands.query import query_data_cli
+from weaviate_cli.commands.restore import restore_backup_cli
+from weaviate_cli.commands.update import (
+    update_collection_cli,
+    update_tenants_cli,
+    update_shards_cli,
+    update_data_cli,
+)
+from click.testing import CliRunner
+from unittest.mock import MagicMock
+import click
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_create_collection_defaults(runner):
+    # Create mock context with config
+    ctx = click.Context(create_collection_cli)
+    ctx.obj = {"config": MagicMock()}
+    ctx.obj["config"].get_client = MagicMock()
+
+    # Mock exists() to return False so create_collection succeeds
+    mock_client = MagicMock()
+    mock_client.collections.exists.side_effect = [False, True]
+    ctx.obj["config"].get_client.return_value = mock_client
+
+    result = runner.invoke(create_collection_cli, obj=ctx.obj)
+    assert result.exit_code == 0, result.output
+    assert CreateCollectionDefaults.collection == CreateCollectionDefaults.collection
+    assert (
+        CreateCollectionDefaults.replication_factor
+        == CreateCollectionDefaults.replication_factor
+    )
+    assert (
+        CreateCollectionDefaults.async_enabled == CreateCollectionDefaults.async_enabled
+    )
+    assert (
+        CreateCollectionDefaults.vector_index == CreateCollectionDefaults.vector_index
+    )
+    assert (
+        CreateCollectionDefaults.training_limit
+        == CreateCollectionDefaults.training_limit
+    )
+    assert CreateCollectionDefaults.multitenant == CreateCollectionDefaults.multitenant
+    assert CreateCollectionDefaults.shards == CreateCollectionDefaults.shards
+
+
+def test_create_tenants_defaults(runner):
+    # Create mock context with config
+    ctx = click.Context(create_tenants_cli)
+    ctx.obj = {"config": MagicMock()}
+    mock_client = MagicMock()
+
+    # Mock exists() to return True so create_collection succeeds
+    mock_client.collections.exists.return_value = True
+    mock_client.get_meta.return_value = {"version": "1.25.0"}
+
+    # Mock collection object
+    mock_collection = MagicMock()
+    mock_client.collections.get.return_value = mock_collection
+
+    # Mock multi-tenancy config
+    mock_config = MagicMock()
+    mock_config.multi_tenancy_config.enabled = True
+    mock_collection.config.get.return_value = mock_config
+
+    # Mock tenants with side effect to return different values on subsequent calls
+    empty_tenants = {}
+    mock_collection.tenants.get.return_value = empty_tenants
+
+    mock_tenants = {
+        f"{CreateTenantsDefaults.tenant_suffix}{i}": MagicMock(
+            activity_status=TenantActivityStatus.ACTIVE
+        )
+        for i in range(CreateTenantsDefaults.number_tenants)
+    }
+    mock_collection.tenants.get_by_names.return_value = mock_tenants
+    ctx.obj["config"].get_client.return_value = mock_client
+
+    result = runner.invoke(create_tenants_cli, obj=ctx.obj)
+    assert result.exit_code == 0, result.output
+    assert CreateTenantsDefaults.collection == CreateTenantsDefaults.collection
+    assert CreateTenantsDefaults.tenant_suffix == CreateTenantsDefaults.tenant_suffix
+    assert CreateTenantsDefaults.number_tenants == CreateTenantsDefaults.number_tenants
+    assert CreateTenantsDefaults.state == CreateTenantsDefaults.state
+
+
+def test_create_backup_defaults(runner):
+    # Create mock context with config
+    ctx = click.Context(create_backup_cli)
+    ctx.obj = {"config": MagicMock()}
+    mock_client = MagicMock()
+    mock_client.collections.exists.return_value = True
+    mock_client.get_meta.return_value = {"version": "1.24.0"}
+    mock_client.backup.create.return_value = MagicMock(
+        status=MagicMock(value="SUCCESS")
+    )
+    ctx.obj["config"].get_client.return_value = mock_client
+
+    result = runner.invoke(create_backup_cli, obj=ctx.obj)
+    assert result.exit_code == 0, result.output
+    assert CreateBackupDefaults.backend == CreateBackupDefaults.backend
+    assert CreateBackupDefaults.backup_id == CreateBackupDefaults.backup_id
+    assert CreateBackupDefaults.include == CreateBackupDefaults.include
+    assert CreateBackupDefaults.exclude == CreateBackupDefaults.exclude
+    assert CreateBackupDefaults.wait == CreateBackupDefaults.wait
+    assert CreateBackupDefaults.cpu_for_backup == CreateBackupDefaults.cpu_for_backup
+
+
+def test_create_data_defaults(runner):
+    # Create mock context with config
+    ctx = click.Context(create_data_cli)
+    ctx.obj = {"config": MagicMock()}
+    ctx.obj["config"].get_client = MagicMock()
+
+    result = runner.invoke(create_data_cli, obj=ctx.obj)
+    assert result.exit_code == 0, result.output
+    assert CreateDataDefaults.collection == CreateDataDefaults.collection
+    assert CreateDataDefaults.limit == CreateDataDefaults.limit
+    assert CreateDataDefaults.consistency_level == CreateDataDefaults.consistency_level
+    assert CreateDataDefaults.randomize == CreateDataDefaults.randomize
+    assert CreateDataDefaults.auto_tenants == CreateDataDefaults.auto_tenants
+    assert CreateDataDefaults.vector_dimensions == CreateDataDefaults.vector_dimensions
+
+
+def test_delete_collection_defaults(runner):
+    # Create mock context with config
+    ctx = click.Context(delete_collection_cli)
+    ctx.obj = {"config": MagicMock()}
+    mock_client = MagicMock()
+    mock_client.collections.exists.side_effect = [True, False]
+    ctx.obj["config"].get_client.return_value = mock_client
+
+    result = runner.invoke(delete_collection_cli, obj=ctx.obj)
+    assert result.exit_code == 0, result.output
+    assert DeleteCollectionDefaults.collection == DeleteCollectionDefaults.collection
+    assert DeleteCollectionDefaults.all == DeleteCollectionDefaults.all
+
+
+def test_delete_tenants_defaults(runner):
+    # Create mock context with config
+    ctx = click.Context(delete_tenants_cli)
+    ctx.obj = {"config": MagicMock()}
+    mock_client = MagicMock()
+    mock_client.get_meta.return_value = {"version": "1.25.0"}
+    mock_client.collections.exists.return_value = True
+
+    # Mock collection object
+    mock_collection = MagicMock()
+    mock_client.collections.get.return_value = mock_collection
+
+    # Mock multi-tenancy config
+    mock_config = MagicMock()
+    mock_config.multi_tenancy_config.enabled = True
+    mock_collection.config.get.return_value = mock_config
+
+    # Mock tenants with side effect to return different values on subsequent calls
+    mock_tenants = {
+        f"{DeleteTenantsDefaults.tenant_suffix}{i}": MagicMock()
+        for i in range(1, DeleteTenantsDefaults.number_tenants + 1)
+    }
+    empty_tenants = {}
+    mock_collection.tenants.get.side_effect = [mock_tenants, empty_tenants]
+
+    ctx.obj["config"].get_client.return_value = mock_client
+
+    result = runner.invoke(delete_tenants_cli, obj=ctx.obj)
+    assert result.exit_code == 0, result.output
+    assert DeleteTenantsDefaults.collection == DeleteTenantsDefaults.collection
+    assert DeleteTenantsDefaults.tenant_suffix == DeleteTenantsDefaults.tenant_suffix
+    assert DeleteTenantsDefaults.number_tenants == DeleteTenantsDefaults.number_tenants
+
+
+def test_delete_data_defaults(runner):
+    # Create mock context with config
+    ctx = click.Context(delete_data_cli)
+    ctx.obj = {"config": MagicMock()}
+    ctx.obj["config"].get_client = MagicMock()
+
+    result = runner.invoke(delete_data_cli, obj=ctx.obj)
+    assert result.exit_code == 0, result.output
+    assert DeleteDataDefaults.collection == DeleteDataDefaults.collection
+    assert DeleteDataDefaults.limit == DeleteDataDefaults.limit
+    assert DeleteDataDefaults.consistency_level == DeleteDataDefaults.consistency_level
+    assert DeleteDataDefaults.uuid == DeleteDataDefaults.uuid
+
+
+def test_get_collection_defaults(runner):
+    # Create mock context with config
+    ctx = click.Context(get_collection_cli)
+    ctx.obj = {"config": MagicMock()}
+    ctx.obj["config"].get_client = MagicMock()
+
+    result = runner.invoke(get_collection_cli, obj=ctx.obj)
+    assert result.exit_code == 0, result.output
+    assert GetCollectionDefaults.collection == GetCollectionDefaults.collection
+
+
+def test_get_tenants_defaults(runner):
+    # Create mock context with config
+    ctx = click.Context(get_tenants_cli)
+    ctx.obj = {"config": MagicMock()}
+    ctx.obj["config"].get_client = MagicMock()
+
+    result = runner.invoke(get_tenants_cli, obj=ctx.obj)
+    assert result.exit_code == 0, result.output
+    assert GetTenantsDefaults.collection == GetTenantsDefaults.collection
+    assert GetTenantsDefaults.verbose == GetTenantsDefaults.verbose
+
+
+def test_get_shards_defaults(runner):
+    # Create mock context with config
+    ctx = click.Context(get_shards_cli)
+    ctx.obj = {"config": MagicMock()}
+    ctx.obj["config"].get_client = MagicMock()
+
+    result = runner.invoke(get_shards_cli, obj=ctx.obj)
+    assert result.exit_code == 0, result.output
+    assert GetShardsDefaults.collection == GetShardsDefaults.collection
+
+
+def test_get_backup_defaults(runner):
+    # Create mock context with config
+    ctx = click.Context(get_backup_cli)
+    ctx.obj = {"config": MagicMock()}
+    ctx.obj["config"].get_client = MagicMock()
+
+    # Mock backup manager
+    backup_manager = MagicMock()
+    backup_manager.get_backup = MagicMock()
+
+    # Mock client
+    client = MagicMock()
+    client.backup = backup_manager
+    ctx.obj["config"].get_client.return_value = client
+
+    result = runner.invoke(get_backup_cli, ["--backup_id", "test-backup"], obj=ctx.obj)
+    assert result.exit_code == 0, result.output
+    assert GetBackupDefaults.backend == GetBackupDefaults.backend
+    assert GetBackupDefaults.backup_id == GetBackupDefaults.backup_id
+    assert GetBackupDefaults.restore == GetBackupDefaults.restore
+
+
+def test_query_data_defaults(runner):
+    # Create mock context with config
+    ctx = click.Context(query_data_cli)
+    ctx.obj = {"config": MagicMock()}
+    ctx.obj["config"].get_client = MagicMock()
+
+    result = runner.invoke(query_data_cli, obj=ctx.obj)
+    assert result.exit_code == 0, result.output
+    assert QueryDataDefaults.collection == QueryDataDefaults.collection
+    assert QueryDataDefaults.search_type == QueryDataDefaults.search_type
+    assert QueryDataDefaults.query == QueryDataDefaults.query
+    assert QueryDataDefaults.consistency_level == QueryDataDefaults.consistency_level
+    assert QueryDataDefaults.limit == QueryDataDefaults.limit
+    assert QueryDataDefaults.properties == QueryDataDefaults.properties
+
+
+def test_restore_backup_defaults(runner):
+    # Create mock context with config
+    ctx = click.Context(restore_backup_cli)
+    ctx.obj = {"config": MagicMock()}
+    ctx.obj["config"].get_client = MagicMock()
+
+    result = runner.invoke(restore_backup_cli, obj=ctx.obj)
+    assert result.exit_code == 0, result.output
+    assert RestoreBackupDefaults.backend == RestoreBackupDefaults.backend
+    assert RestoreBackupDefaults.backup_id == RestoreBackupDefaults.backup_id
+    assert RestoreBackupDefaults.wait == RestoreBackupDefaults.wait
+    assert RestoreBackupDefaults.include == RestoreBackupDefaults.include
+    assert RestoreBackupDefaults.exclude == RestoreBackupDefaults.exclude
+
+
+def test_update_collection_defaults(runner):
+    # Create mock context with config
+    ctx = click.Context(update_collection_cli)
+    ctx.obj = {"config": MagicMock()}
+
+    # Mock exists() to return False so create_collection succeeds
+    mock_client = MagicMock()
+    mock_client.collections.exists.side_effect = [True, True]
+
+    # Mock collection object and replication factor
+    mock_collection = MagicMock()
+    mock_config = MagicMock()
+    mock_config.replication_config.factor = 3
+    mock_config.multi_tenancy_config.enabled = True
+    mock_config.multi_tenancy_config.auto_tenant_creation = False
+    mock_config.multi_tenancy_config.auto_tenant_activation = False
+    mock_collection.config.get.return_value = mock_config
+    mock_client.collections.get.return_value = mock_collection
+
+    ctx.obj["config"].get_client.return_value = mock_client
+
+    result = runner.invoke(update_collection_cli, obj=ctx.obj)
+    assert result.exit_code == 0, result.output
+    assert UpdateCollectionDefaults.collection == UpdateCollectionDefaults.collection
+    assert (
+        UpdateCollectionDefaults.async_enabled == UpdateCollectionDefaults.async_enabled
+    )
+    assert (
+        UpdateCollectionDefaults.vector_index == UpdateCollectionDefaults.vector_index
+    )
+    assert UpdateCollectionDefaults.description == UpdateCollectionDefaults.description
+    assert (
+        UpdateCollectionDefaults.training_limit
+        == UpdateCollectionDefaults.training_limit
+    )
+    assert (
+        UpdateCollectionDefaults.auto_tenant_creation
+        == UpdateCollectionDefaults.auto_tenant_creation
+    )
+    assert (
+        UpdateCollectionDefaults.auto_tenant_activation
+        == UpdateCollectionDefaults.auto_tenant_activation
+    )
+    assert (
+        UpdateCollectionDefaults.replication_deletion_strategy
+        == UpdateCollectionDefaults.replication_deletion_strategy
+    )
+
+
+def test_update_tenants_defaults(runner):
+    # Create mock context with config
+    ctx = click.Context(update_tenants_cli)
+    ctx.obj = {"config": MagicMock()}
+    mock_client = MagicMock()
+
+    # Mock exists() to return True so create_collection succeeds
+    mock_client.collections.exists.return_value = True
+    mock_client.get_meta.return_value = {"version": "1.25.0"}
+
+    # Mock collection object
+    mock_collection = MagicMock()
+    mock_client.collections.get.return_value = mock_collection
+
+    # Mock multi-tenancy config
+    mock_config = MagicMock()
+    mock_config.multi_tenancy_config.enabled = True
+    mock_collection.config.get.return_value = mock_config
+
+    # Mock tenants with side effect to return different values on subsequent calls
+    mock_tenants = {
+        f"{UpdateTenantsDefaults.tenant_suffix}{i}": MagicMock(
+            activity_status=TenantActivityStatus.ACTIVE
+        )
+        for i in range(UpdateTenantsDefaults.number_tenants)
+    }
+    mock_collection.tenants.get.return_value = mock_tenants
+
+    updated_tenants = {
+        f"{UpdateTenantsDefaults.tenant_suffix}{i}": MagicMock(
+            activity_status=TenantActivityStatus.ACTIVE
+        )
+        for i in range(UpdateTenantsDefaults.number_tenants)
+    }
+    mock_collection.tenants.get_by_names.return_value = updated_tenants
+    ctx.obj["config"].get_client.return_value = mock_client
+
+    result = runner.invoke(update_tenants_cli, obj=ctx.obj)
+    assert result.exit_code == 0, result.output
+    assert UpdateTenantsDefaults.collection == UpdateTenantsDefaults.collection
+    assert UpdateTenantsDefaults.tenant_suffix == UpdateTenantsDefaults.tenant_suffix
+    assert UpdateTenantsDefaults.number_tenants == UpdateTenantsDefaults.number_tenants
+    assert UpdateTenantsDefaults.state == UpdateTenantsDefaults.state
+
+
+def test_update_shards_defaults(runner):
+    # Create mock context with config
+    ctx = click.Context(update_shards_cli)
+    ctx.obj = {"config": MagicMock()}
+    ctx.obj["config"].get_client = MagicMock()
+
+    result = runner.invoke(update_shards_cli, obj=ctx.obj)
+    assert result.exit_code == 0, result.output
+    assert UpdateShardsDefaults.collection == UpdateShardsDefaults.collection
+    assert UpdateShardsDefaults.status == UpdateShardsDefaults.status
+    assert UpdateShardsDefaults.shards == UpdateShardsDefaults.shards
+    assert UpdateShardsDefaults.all == UpdateShardsDefaults.all
+
+
+def test_update_data_defaults(runner):
+    # Create mock context with config
+    ctx = click.Context(update_data_cli)
+    ctx.obj = {"config": MagicMock()}
+    ctx.obj["config"].get_client = MagicMock()
+
+    result = runner.invoke(update_data_cli, obj=ctx.obj)
+    assert result.exit_code == 0, result.output
+    assert UpdateDataDefaults.collection == UpdateDataDefaults.collection
+    assert UpdateDataDefaults.limit == UpdateDataDefaults.limit
+    assert UpdateDataDefaults.consistency_level == UpdateDataDefaults.consistency_level
+    assert UpdateDataDefaults.randomize == UpdateDataDefaults.randomize

--- a/test/unittests/test_managers/test_collection_manager.py
+++ b/test/unittests/test_managers/test_collection_manager.py
@@ -20,17 +20,8 @@ def test_create_collection(mock_client):
     manager.create_collection(
         collection="TestCollection",
         replication_factor=3,
-        async_enabled=True,
         vector_index="hnsw",
-        inverted_index=None,
-        training_limit=10000,
-        multitenant=False,
-        auto_tenant_creation=False,
-        auto_tenant_activation=False,
-        force_auto_schema=False,
-        shards=1,
-        vectorizer=None,
-        replication_deletion_strategy=None,
+        async_enabled=True,
     )
 
     # Verify the collection creation was called with correct parameters
@@ -58,18 +49,6 @@ def test_create_existing_collection(mock_client):
     with pytest.raises(Exception) as exc_info:
         manager.create_collection(
             collection="TestCollection",
-            replication_factor=3,
-            async_enabled=True,
-            vector_index="hnsw",
-            inverted_index=None,
-            training_limit=10000,
-            multitenant=False,
-            auto_tenant_creation=False,
-            auto_tenant_activation=False,
-            force_auto_schema=False,
-            shards=1,
-            vectorizer=None,
-            replication_deletion_strategy=None,
         )
 
     # Verify the error message
@@ -95,18 +74,6 @@ def test_create_collection_failure(mock_client):
     with pytest.raises(Exception) as exc_info:
         manager.create_collection(
             collection="TestCollection",
-            replication_factor=3,
-            async_enabled=True,
-            vector_index="hnsw",
-            inverted_index=None,
-            training_limit=10000,
-            multitenant=False,
-            auto_tenant_creation=False,
-            auto_tenant_activation=False,
-            force_auto_schema=False,
-            shards=1,
-            vectorizer=None,
-            replication_deletion_strategy=None,
         )
 
     # Verify the error message
@@ -178,7 +145,6 @@ def test_update_collection(mock_client):
         collection="TestCollection",
         description="Updated description",
         vector_index="hnsw",
-        training_limit=10000,
         async_enabled=True,
         auto_tenant_creation=True,
         auto_tenant_activation=True,

--- a/test/unittests/test_managers/test_data_manager.py
+++ b/test/unittests/test_managers/test_data_manager.py
@@ -18,13 +18,10 @@ def test_ingest_data(mock_client):
     )
 
     # Test data ingestion
-    manager.ingest_data(
+    manager.create_data(
         collection="TestCollection",
         limit=100,
-        consistency_level="quorum",
         randomize=True,
-        auto_tenants=0,
-        vector_dimensions=1536,
     )
 
     mock_client.collections.get.assert_called_once_with("TestCollection")
@@ -43,7 +40,6 @@ def test_update_data(mock_client):
     manager.update_data(
         collection="TestCollection",
         limit=100,
-        consistency_level="quorum",
         randomize=True,
     )
 
@@ -61,7 +57,8 @@ def test_delete_data(mock_client):
 
     # Test data deletion
     manager.delete_data(
-        collection="TestCollection", limit=100, consistency_level="quorum"
+        collection="TestCollection",
+        limit=100,
     )
 
     mock_client.collections.get.assert_called_once_with("TestCollection")

--- a/weaviate_cli/commands/cancel.py
+++ b/weaviate_cli/commands/cancel.py
@@ -2,6 +2,7 @@ import click
 import sys
 from weaviate_cli.utils import get_client_from_context
 from weaviate_cli.managers.backup_manager import BackupManager
+from weaviate_cli.defaults import CancelBackupDefaults
 
 
 # Create Group
@@ -14,13 +15,13 @@ def cancel():
 @cancel.command("backup")
 @click.option(
     "--backend",
-    default="s3",
+    default=CancelBackupDefaults.backend,
     type=click.Choice(["s3", "gcs", "filesystem"]),
     help="The backend used for storing the backups (default: s3).",
 )
 @click.option(
     "--backup_id",
-    default="test-backup",
+    default=CancelBackupDefaults.backup_id,
     help="Identifier used for the backup (default: test-backup).",
 )
 @click.pass_context

--- a/weaviate_cli/commands/create.py
+++ b/weaviate_cli/commands/create.py
@@ -7,6 +7,10 @@ from weaviate_cli.managers.collection_manager import CollectionManager
 from weaviate_cli.managers.tenant_manager import TenantManager
 from weaviate_cli.managers.data_manager import DataManager
 from weaviate.exceptions import WeaviateConnectionError
+from weaviate_cli.defaults import CreateBackupDefaults
+from weaviate_cli.defaults import CreateCollectionDefaults
+from weaviate_cli.defaults import CreateTenantsDefaults
+from weaviate_cli.defaults import CreateDataDefaults
 
 
 # Create Group
@@ -19,15 +23,23 @@ def create() -> None:
 # Subcommand to create a collection
 @create.command("collection")
 @click.option(
-    "--collection", default="Movies", help="The name of the collection to create."
+    "--collection",
+    default=CreateCollectionDefaults.collection,
+    help="The name of the collection to create.",
 )
 @click.option(
-    "--replication_factor", default=3, help="Replication factor (default: 3)."
+    "--replication_factor",
+    default=CreateCollectionDefaults.replication_factor,
+    help="Replication factor (default: 3).",
 )
-@click.option("--async_enabled", is_flag=True, help="Enable async (default: False).")
+@click.option(
+    "--async_enabled",
+    is_flag=True,
+    help="Enable async (default: False).",
+)
 @click.option(
     "--vector_index",
-    default="hnsw",
+    default=CreateCollectionDefaults.vector_index,
     type=click.Choice(
         [
             "hnsw",
@@ -44,13 +56,13 @@ def create() -> None:
 )
 @click.option(
     "--inverted_index",
-    default=None,
+    default=CreateCollectionDefaults.inverted_index,
     type=click.Choice(["timestamp", "null", "length"]),
     help="Inverted index properties (default: None). Options: 'timestamp'==index_timestamps, 'null'==index_null_state, 'length'==index_property_length.",
 )
 @click.option(
     "--training_limit",
-    default=10000,
+    default=CreateCollectionDefaults.training_limit,
     help="Training limit for PQ and SQ (default: 10000).",
 )
 @click.option(
@@ -71,16 +83,20 @@ def create() -> None:
     is_flag=True,
     help="Force auto-schema (default: False). If passed, no properties will be added to the collection and it will be the auto-schema the one that infers the properties.",
 )
-@click.option("--shards", default=1, help="Number of shards (default: 1).")
+@click.option(
+    "--shards",
+    default=CreateCollectionDefaults.shards,
+    help="Number of shards (default: 1).",
+)
 @click.option(
     "--vectorizer",
-    default=None,
+    default=CreateCollectionDefaults.vectorizer,
     type=click.Choice(["contextionary", "transformers", "openai", "ollama"]),
     help="Vectorizer to use.",
 )
 @click.option(
     "--replication_deletion_strategy",
-    default="delete_on_conflict",
+    default=CreateCollectionDefaults.replication_deletion_strategy,
     type=click.Choice(["delete_on_conflict", "no_automated_resolution"]),
     help="Replication deletion strategy (default: 'delete_on_conflict').",
 )
@@ -136,19 +152,23 @@ def create_collection_cli(
 # Subcommand to create tenants
 @create.command("tenants")
 @click.option(
-    "--collection", default="Movies", help="The name of the collection to create."
+    "--collection",
+    default=CreateTenantsDefaults.collection,
+    help="The name of the collection to create.",
 )
 @click.option(
     "--tenant_suffix",
-    default="Tenant--",
+    default=CreateTenantsDefaults.tenant_suffix,
     help="The suffix to add to the tenant name (default: 'Tenant--').",
 )
 @click.option(
-    "--number_tenants", default=100, help="Number of tenants to create (default: 100)."
+    "--number_tenants",
+    default=CreateTenantsDefaults.number_tenants,
+    help="Number of tenants to create (default: 100).",
 )
 @click.option(
     "--state",
-    default="active",
+    default=CreateTenantsDefaults.state,
     type=click.Choice(["hot", "active", "cold", "inactive", "frozen", "offloaded"]),
 )
 @click.pass_context
@@ -179,23 +199,23 @@ def create_tenants_cli(ctx, collection, tenant_suffix, number_tenants, state):
 @create.command("backup")
 @click.option(
     "--backend",
-    default="s3",
+    default=CreateBackupDefaults.backend,
     type=click.Choice(["s3", "gcs", "filesystem"]),
     help="The backend used for storing the backups (default: s3).",
 )
 @click.option(
     "--backup_id",
-    default="test-backup",
+    default=CreateBackupDefaults.backup_id,
     help="Identifier used for the backup (default: test-backup).",
 )
 @click.option(
     "--include",
-    default=None,
+    default=CreateBackupDefaults.include,
     help="Comma separated list of collections to include in the backup. If not provided, all collections will be included.",
 )
 @click.option(
     "--exclude",
-    default=None,
+    default=CreateBackupDefaults.exclude,
     help="Comma separated list of collections to exclude from the backup. If not provided, all collections will be included.",
 )
 @click.option(
@@ -203,7 +223,7 @@ def create_tenants_cli(ctx, collection, tenant_suffix, number_tenants, state):
 )
 @click.option(
     "--cpu_for_backup",
-    default=40,
+    default=CreateBackupDefaults.cpu_for_backup,
     help="The percentage of CPU to use for the backup (default: 40). The larger, the faster it will occur, but it will also consume more memory.",
 )
 @click.pass_context
@@ -236,27 +256,29 @@ def create_backup_cli(ctx, backend, backup_id, include, exclude, wait, cpu_for_b
 @create.command("data")
 @click.option(
     "--collection",
-    default="Movies",
+    default=CreateDataDefaults.collection,
     help="The name of the collection to ingest data into.",
 )
 @click.option(
-    "--limit", default=1000, help="Number of objects to import (default: 1000)."
+    "--limit",
+    default=CreateDataDefaults.limit,
+    help="Number of objects to import (default: 1000).",
 )
 @click.option(
     "--consistency_level",
-    default="quorum",
+    default=CreateDataDefaults.consistency_level,
     type=click.Choice(["quorum", "all", "one"]),
     help="Consistency level (default: 'quorum').",
 )
 @click.option("--randomize", is_flag=True, help="Randomize the data (default: False).")
 @click.option(
     "--auto_tenants",
-    default=0,
+    default=CreateDataDefaults.auto_tenants,
     help="Number of tenants for which we will send data. NOTE: Requires class with --auto_tenant_creation (default: 0).",
 )
 @click.option(
     "--vector_dimensions",
-    default=1536,
+    default=CreateDataDefaults.vector_dimensions,
     help="Number of vector dimensions to be used when the data is randomized.",
 )
 @click.pass_context
@@ -282,7 +304,7 @@ def create_data_cli(
         client = get_client_from_context(ctx)
         data_manager = DataManager(client)
         # Call the function from ingest_data.py with general and specific arguments
-        data_manager.ingest_data(
+        data_manager.create_data(
             collection=collection,
             limit=limit,
             consistency_level=consistency_level,

--- a/weaviate_cli/commands/delete.py
+++ b/weaviate_cli/commands/delete.py
@@ -5,6 +5,9 @@ from weaviate_cli.utils import get_client_from_context
 from weaviate_cli.managers.collection_manager import CollectionManager
 from weaviate_cli.managers.data_manager import DataManager
 from weaviate.exceptions import WeaviateConnectionError
+from weaviate_cli.defaults import DeleteCollectionDefaults
+from weaviate_cli.defaults import DeleteTenantsDefaults
+from weaviate_cli.defaults import DeleteDataDefaults
 
 
 # Delete Group
@@ -16,7 +19,9 @@ def delete() -> None:
 
 @delete.command("collection")
 @click.option(
-    "--collection", default="Movies", help="The name of the collection to delete."
+    "--collection",
+    default=DeleteCollectionDefaults.collection,
+    help="The name of the collection to delete.",
 )
 @click.option("--all", is_flag=True, help="Delete all collections (default: False).")
 @click.pass_context
@@ -42,16 +47,18 @@ def delete_collection_cli(ctx: click.Context, collection: str, all: bool) -> Non
 @delete.command("tenants")
 @click.option(
     "--collection",
-    default="Movies",
+    default=DeleteTenantsDefaults.collection,
     help="The name of the collection to delete tenants from.",
 )
 @click.option(
     "--tenant_suffix",
-    default="Tenant--",
+    default=DeleteTenantsDefaults.tenant_suffix,
     help="The suffix to add to the tenant name (default: 'Tenant--').",
 )
 @click.option(
-    "--number_tenants", default=100, help="Number of tenants to delete (default: 100)."
+    "--number_tenants",
+    default=DeleteTenantsDefaults.number_tenants,
+    help="Number of tenants to delete (default: 100).",
 )
 @click.pass_context
 def delete_tenants_cli(
@@ -81,20 +88,23 @@ def delete_tenants_cli(
 @delete.command("data")
 @click.option(
     "--collection",
-    default="Movies",
+    default=DeleteDataDefaults.collection,
     help="The name of the collection to delete tenants from.",
 )
 @click.option(
-    "--limit", default=100, help="Number of objects to delete (default: 100)."
+    "--limit",
+    default=DeleteDataDefaults.limit,
+    help="Number of objects to delete (default: 100).",
 )
 @click.option(
     "--consistency_level",
-    default="quorum",
+    default=DeleteDataDefaults.consistency_level,
     type=click.Choice(["quorum", "all", "one"]),
     help="Consistency level (default: 'quorum').",
 )
 @click.option(
     "--uuid",
+    default=DeleteDataDefaults.uuid,
     help="UUID of the oject to be deleted. If provided, --limit will be ignored.",
 )
 @click.pass_context

--- a/weaviate_cli/commands/get.py
+++ b/weaviate_cli/commands/get.py
@@ -6,6 +6,10 @@ from weaviate_cli.managers.collection_manager import CollectionManager
 from weaviate_cli.managers.backup_manager import BackupManager
 from weaviate_cli.managers.shard_manager import ShardManager
 from weaviate.exceptions import WeaviateConnectionError
+from weaviate_cli.defaults import GetBackupDefaults
+from weaviate_cli.defaults import GetTenantsDefaults
+from weaviate_cli.defaults import GetShardsDefaults
+from weaviate_cli.defaults import GetCollectionDefaults
 
 
 # Get Group
@@ -16,7 +20,11 @@ def get():
 
 
 @get.command("collection")
-@click.option("--collection", default=None, help="The name of the collection to get.")
+@click.option(
+    "--collection",
+    default=GetCollectionDefaults.collection,
+    help="The name of the collection to get.",
+)
 @click.pass_context
 def get_collection_cli(ctx, collection):
     """Get all collections in Weaviate. If --collection is provided, get the specific collection."""
@@ -40,7 +48,7 @@ def get_collection_cli(ctx, collection):
 @get.command("tenants")
 @click.option(
     "--collection",
-    default="Movies",
+    default=GetTenantsDefaults.collection,
     help="The name of the collection to get tenants from.",
 )
 @click.option("--verbose", is_flag=True, help="Print verbose output.")
@@ -69,7 +77,7 @@ def get_tenants_cli(ctx, collection, verbose):
 @get.command("shards")
 @click.option(
     "--collection",
-    default=None,
+    default=GetShardsDefaults.collection,
     help="The name of the collection to get tenants from.",
 )
 @click.pass_context
@@ -97,13 +105,13 @@ def get_shards_cli(ctx, collection):
 @get.command("backup")
 @click.option(
     "--backend",
-    default="s3",
+    default=GetBackupDefaults.backend,
     type=click.Choice(["s3", "gcs", "filesystem"]),
     help="The backend used for storing the backups (default: s3).",
 )
 @click.option(
     "--backup_id",
-    default=None,
+    default=GetBackupDefaults.backup_id,
     help="Identifier for the backup you want to get its status.",
 )
 @click.option(

--- a/weaviate_cli/commands/query.py
+++ b/weaviate_cli/commands/query.py
@@ -3,6 +3,7 @@ import click
 from weaviate_cli.utils import get_client_from_context
 from weaviate_cli.managers.data_manager import DataManager
 from weaviate.exceptions import WeaviateConnectionError
+from weaviate_cli.defaults import QueryDataDefaults
 
 
 # Query Group
@@ -14,29 +15,35 @@ def query() -> None:
 
 @query.command("data")
 @click.option(
-    "--collection", default="Movies", help="The name of the collection to query."
+    "--collection",
+    default=QueryDataDefaults.collection,
+    help="The name of the collection to query.",
 )
 @click.option(
     "--search_type",
-    default="fetch",
+    default=QueryDataDefaults.search_type,
     type=click.Choice(["fetch", "vector", "keyword", "hybrid", "uuid"]),
     help='Search type (default: "fetch").',
 )
 @click.option(
     "--query",
-    default="Action movie",
+    default=QueryDataDefaults.query,
     help="Query string for the search. Only used when search type is vector, keyword or hybrid (default: 'Action movie').",
 )
 @click.option(
     "--consistency_level",
-    default="quorum",
+    default=QueryDataDefaults.consistency_level,
     type=click.Choice(["quorum", "all", "one"]),
     help="Consistency level (default: 'quorum').",
 )
-@click.option("--limit", default=10, help="Number of objects to query (default: 10).")
+@click.option(
+    "--limit",
+    default=QueryDataDefaults.limit,
+    help="Number of objects to query (default: 10).",
+)
 @click.option(
     "--properties",
-    default="title,keywords",
+    default=QueryDataDefaults.properties,
     help="Properties from the object to display (default: 'title, keywords').",
 )
 @click.pass_context

--- a/weaviate_cli/commands/restore.py
+++ b/weaviate_cli/commands/restore.py
@@ -3,6 +3,7 @@ import click
 from weaviate_cli.managers.backup_manager import BackupManager
 from weaviate_cli.utils import get_client_from_context
 from weaviate.exceptions import WeaviateConnectionError
+from weaviate_cli.defaults import RestoreBackupDefaults
 
 
 # Restore Group
@@ -15,13 +16,13 @@ def restore() -> None:
 @restore.command("backup")
 @click.option(
     "--backend",
-    default="s3",
+    default=RestoreBackupDefaults.backend,
     type=click.Choice(["s3", "gcs", "filesystem"]),
     help="The backend used for storing the backups (default: s3).",
 )
 @click.option(
     "--backup_id",
-    default="test-backup",
+    default=RestoreBackupDefaults.backup_id,
     help="Identifier used for the backup (default: test-backup).",
 )
 @click.option(
@@ -29,12 +30,12 @@ def restore() -> None:
 )
 @click.option(
     "--include",
-    default=None,
+    default=RestoreBackupDefaults.include,
     help="Collection to include in backup (default: None).",
 )
 @click.option(
     "--exclude",
-    default=None,
+    default=RestoreBackupDefaults.exclude,
     help="Collection to exclude in backup (default: None).",
 )
 @click.pass_context

--- a/weaviate_cli/commands/update.py
+++ b/weaviate_cli/commands/update.py
@@ -7,6 +7,10 @@ from weaviate_cli.managers.collection_manager import CollectionManager
 from weaviate_cli.managers.shard_manager import ShardManager
 from weaviate_cli.managers.data_manager import DataManager
 from weaviate.exceptions import WeaviateConnectionError
+from weaviate_cli.defaults import UpdateCollectionDefaults
+from weaviate_cli.defaults import UpdateTenantsDefaults
+from weaviate_cli.defaults import UpdateShardsDefaults
+from weaviate_cli.defaults import UpdateDataDefaults
 
 
 # Update Group
@@ -18,42 +22,49 @@ def update() -> None:
 
 @update.command("collection")
 @click.option(
-    "--collection", default="Movies", help="The name of the collection to update."
+    "--collection",
+    default=UpdateCollectionDefaults.collection,
+    help="The name of the collection to update.",
 )
 @click.option(
-    "--async_enabled", default=None, type=bool, help="Enable async (default: None)."
+    "--async_enabled",
+    default=UpdateCollectionDefaults.async_enabled,
+    type=bool,
+    help="Enable async (default: None).",
 )
 @click.option(
     "--vector_index",
-    default=None,
+    default=UpdateCollectionDefaults.vector_index,
     type=click.Choice(
         ["hnsw", "flat", "hnsw_pq", "hnsw_bq", "hnsw_sq", "flat_bq", "hnsw_acorn"]
     ),
     help='Vector index type (default: "None").',
 )
 @click.option(
-    "--description", default=None, help="collection description (default: None)."
+    "--description",
+    default=UpdateCollectionDefaults.description,
+    help="collection description (default: None).",
 )
 @click.option(
     "--training_limit",
-    default=10000,
+    default=UpdateCollectionDefaults.training_limit,
     help="Training limit for PQ and SQ (default: 10000).",
 )
 @click.option(
     "--auto_tenant_creation",
-    default=None,
+    default=UpdateCollectionDefaults.auto_tenant_creation,
     type=bool,
     help="Enable auto tenant creation (default: None).",
 )
 @click.option(
     "--auto_tenant_activation",
-    default=None,
+    default=UpdateCollectionDefaults.auto_tenant_activation,
     type=bool,
     help="Enable auto tenant activation (default: None).",
 )
 @click.option(
     "--replication_deletion_strategy",
-    default=None,
+    default=UpdateCollectionDefaults.replication_deletion_strategy,
     type=click.Choice(["delete_on_conflict", "no_automated_resolution"]),
     help="Replication deletion strategy.",
 )
@@ -98,19 +109,23 @@ def update_collection_cli(
 
 @update.command("tenants")
 @click.option(
-    "--collection", default="Movies", help="The name of the collection to update."
+    "--collection",
+    default=UpdateTenantsDefaults.collection,
+    help="The name of the collection to update.",
 )
 @click.option(
     "--tenant_suffix",
-    default="Tenant--",
+    default=UpdateTenantsDefaults.tenant_suffix,
     help="The suffix to add to the tenant name (default: 'Tenant--').",
 )
 @click.option(
-    "--number_tenants", default=100, help="Number of tenants to update (default: 100)."
+    "--number_tenants",
+    default=UpdateTenantsDefaults.number_tenants,
+    help="Number of tenants to update (default: 100).",
 )
 @click.option(
     "--state",
-    default="active",
+    default=UpdateTenantsDefaults.state,
     type=click.Choice(["hot", "active", "cold", "inactive", "frozen", "offloaded"]),
 )
 @click.pass_context
@@ -140,18 +155,18 @@ def update_tenants_cli(ctx, collection, tenant_suffix, number_tenants, state):
 @update.command("shards")
 @click.option(
     "--collection",
-    default=None,
+    default=UpdateShardsDefaults.collection,
     help="The name of the collection to update.",
 )
 @click.option(
     "--status",
-    default="READY",
+    default=UpdateShardsDefaults.status,
     type=click.Choice(["READY", "READONLY"]),
     help="The status of the shards.",
 )
 @click.option(
     "--shards",
-    default=None,
+    default=UpdateShardsDefaults.shards,
     help="Comma separated list of shards to update.",
 )
 @click.option(
@@ -192,14 +207,18 @@ def update_shards_cli(
 
 @update.command("data")
 @click.option(
-    "--collection", default="Movies", help="The name of the collection to update."
+    "--collection",
+    default=UpdateDataDefaults.collection,
+    help="The name of the collection to update.",
 )
 @click.option(
-    "--limit", default=100, help="Number of objects to update (default: 100)."
+    "--limit",
+    default=UpdateDataDefaults.limit,
+    help="Number of objects to update (default: 100).",
 )
 @click.option(
     "--consistency_level",
-    default="quorum",
+    default=UpdateDataDefaults.consistency_level,
     type=click.Choice(["quorum", "all", "one"]),
     help="Consistency level (default: 'quorum').",
 )

--- a/weaviate_cli/defaults.py
+++ b/weaviate_cli/defaults.py
@@ -1,0 +1,152 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class CreateCollectionDefaults:
+    collection: str = "Movies"
+    replication_factor: int = 3
+    async_enabled: bool = False
+    vector_index: str = "hnsw"
+    inverted_index: Optional[str] = None
+    training_limit: int = 10000
+    multitenant: bool = False
+    auto_tenant_creation: bool = False
+    auto_tenant_activation: bool = False
+    force_auto_schema: bool = False
+    shards: int = 1
+    vectorizer: Optional[str] = None
+    replication_deletion_strategy: str = "delete_on_conflict"
+
+
+@dataclass
+class CreateTenantsDefaults:
+    collection: str = "Movies"
+    tenant_suffix: str = "Tenant--"
+    number_tenants: int = 100
+    state: str = "active"
+
+
+@dataclass
+class CreateBackupDefaults:
+    backend: str = "s3"
+    backup_id: str = "test-backup"
+    include: Optional[str] = None
+    exclude: Optional[str] = None
+    wait: bool = False
+    cpu_for_backup: int = 40
+
+
+@dataclass
+class CreateDataDefaults:
+    collection: str = "Movies"
+    limit: int = 1000
+    consistency_level: str = "quorum"
+    randomize: bool = False
+    auto_tenants: int = 0
+    vector_dimensions: int = 1536
+
+
+@dataclass
+class CancelBackupDefaults:
+    backend: str = "s3"
+    backup_id: str = "test-backup"
+
+
+@dataclass
+class DeleteCollectionDefaults:
+    collection: str = "Movies"
+    all: bool = False
+
+
+@dataclass
+class DeleteTenantsDefaults:
+    collection: str = "Movies"
+    tenant_suffix: str = "Tenant--"
+    number_tenants: int = 100
+
+
+@dataclass
+class DeleteDataDefaults:
+    collection: str = "Movies"
+    limit: int = 100
+    consistency_level: str = "quorum"
+    uuid: Optional[str] = None
+
+
+@dataclass
+class GetCollectionDefaults:
+    collection: Optional[str] = None
+
+
+@dataclass
+class GetTenantsDefaults:
+    collection: str = "Movies"
+    verbose: bool = False
+
+
+@dataclass
+class GetShardsDefaults:
+    collection: Optional[str] = None
+
+
+@dataclass
+class GetBackupDefaults:
+    backend: str = "s3"
+    backup_id: Optional[str] = None
+    restore: bool = False
+
+
+@dataclass
+class QueryDataDefaults:
+    collection: str = "Movies"
+    search_type: str = "fetch"
+    query: str = "Action movie"
+    consistency_level: str = "quorum"
+    limit: int = 10
+    properties: str = "title,keywords"
+
+
+@dataclass
+class RestoreBackupDefaults:
+    backend: str = "s3"
+    backup_id: str = "test-backup"
+    wait: bool = False
+    include: Optional[str] = None
+    exclude: Optional[str] = None
+
+
+@dataclass
+class UpdateCollectionDefaults:
+    collection: str = "Movies"
+    async_enabled: Optional[bool] = None
+    vector_index: Optional[str] = None
+    description: Optional[str] = None
+    training_limit: int = 10000
+    auto_tenant_creation: Optional[bool] = None
+    auto_tenant_activation: Optional[bool] = None
+    replication_deletion_strategy: Optional[str] = None
+
+
+@dataclass
+class UpdateTenantsDefaults:
+    collection: str = "Movies"
+    tenant_suffix: str = "Tenant--"
+    number_tenants: int = 100
+    state: str = "active"
+
+
+@dataclass
+class UpdateShardsDefaults:
+    collection: Optional[str] = None
+    status: str = "READY"
+    shards: Optional[str] = None
+    all: bool = False
+
+
+@dataclass
+class UpdateDataDefaults:
+    collection: str = "Movies"
+    limit: int = 100
+    consistency_level: str = "quorum"
+    randomize: bool = False

--- a/weaviate_cli/managers/backup_manager.py
+++ b/weaviate_cli/managers/backup_manager.py
@@ -1,8 +1,14 @@
 import semver
 import click
-
+from typing import Optional
 from weaviate.backup.backup import BackupConfigCreate
 from weaviate.client import WeaviateClient
+from weaviate_cli.defaults import (
+    CancelBackupDefaults,
+    CreateBackupDefaults,
+    RestoreBackupDefaults,
+    GetBackupDefaults,
+)
 
 
 class BackupManager:
@@ -11,12 +17,12 @@ class BackupManager:
 
     def create_backup(
         self,
-        backup_id: str,
-        backend,
-        include: str,
-        exclude: str,
-        wait: bool,
-        cpu_for_backup: int,
+        backup_id: str = CreateBackupDefaults.backup_id,
+        backend: str = CreateBackupDefaults.backend,
+        include: Optional[str] = CreateBackupDefaults.include,
+        exclude: Optional[str] = CreateBackupDefaults.exclude,
+        wait: bool = CreateBackupDefaults.wait,
+        cpu_for_backup: int = CreateBackupDefaults.cpu_for_backup,
     ) -> None:
 
         version = semver.Version.parse(self.client.get_meta()["version"])
@@ -56,7 +62,12 @@ class BackupManager:
         click.echo(f"Backup '{backup_id}' created successfully in Weaviate.")
 
     def restore_backup(
-        self, backup_id: str, backend, include: str, exclude: str, wait: bool
+        self,
+        backup_id: str = RestoreBackupDefaults.backup_id,
+        backend: str = RestoreBackupDefaults.backend,
+        include: Optional[str] = RestoreBackupDefaults.include,
+        exclude: Optional[str] = RestoreBackupDefaults.exclude,
+        wait: bool = RestoreBackupDefaults.wait,
     ) -> None:
 
         result = self.client.backup.restore(
@@ -75,7 +86,12 @@ class BackupManager:
 
         click.echo(f"Backup '{backup_id}' restored successfully in Weaviate.")
 
-    def get_backup(self, backend: str, backup_id: str, restore: bool) -> None:
+    def get_backup(
+        self,
+        backend: str = GetBackupDefaults.backend,
+        backup_id: str = GetBackupDefaults.backup_id,
+        restore: bool = GetBackupDefaults.restore,
+    ) -> None:
 
         if restore:
             backup = self.client.backup.get_restore_status(
@@ -108,7 +124,11 @@ class BackupManager:
                 #       print(f"Collections: {backup.collections}")
                 #     print("------------------------------")
 
-    def cancel_backup(self, backend: str, backup_id: str) -> None:
+    def cancel_backup(
+        self,
+        backend: str = CancelBackupDefaults.backend,
+        backup_id: str = CancelBackupDefaults.backup_id,
+    ) -> None:
         if self.client.backup.cancel(backend=backend, backup_id=backup_id):
             click.echo(f"Backup '{backup_id}' cancelled successfully in Weaviate.")
         else:

--- a/weaviate_cli/managers/collection_manager.py
+++ b/weaviate_cli/managers/collection_manager.py
@@ -5,6 +5,12 @@ from weaviate.client import WeaviateClient
 from weaviate.collections import Collection
 from weaviate.collections.classes.tenants import TenantActivityStatus
 from weaviate.classes.config import VectorFilterStrategy
+from weaviate_cli.defaults import (
+    CreateCollectionDefaults,
+    UpdateCollectionDefaults,
+    DeleteCollectionDefaults,
+    GetCollectionDefaults,
+)
 import weaviate.classes.config as wvc
 
 
@@ -22,7 +28,9 @@ class CollectionManager:
             )
         return acc
 
-    def get_collection(self, collection: Optional[str]) -> None:
+    def get_collection(
+        self, collection: Optional[str] = GetCollectionDefaults.collection
+    ) -> None:
 
         if collection is not None:
             if not self.client.collections.exists(collection):
@@ -47,19 +55,21 @@ class CollectionManager:
 
     def create_collection(
         self,
-        collection: str,
-        replication_factor: int,
-        async_enabled: bool,
-        vector_index: str,
-        inverted_index: Optional[str],
-        training_limit: int,
-        multitenant: bool,
-        auto_tenant_creation: bool,
-        auto_tenant_activation: bool,
-        force_auto_schema: bool,
-        shards: int,
-        vectorizer: Optional[str],
-        replication_deletion_strategy: Optional[str],
+        collection: str = CreateCollectionDefaults.collection,
+        replication_factor: int = CreateCollectionDefaults.replication_factor,
+        async_enabled: bool = CreateCollectionDefaults.async_enabled,
+        vector_index: str = CreateCollectionDefaults.vector_index,
+        inverted_index: Optional[str] = CreateCollectionDefaults.inverted_index,
+        training_limit: int = CreateCollectionDefaults.training_limit,
+        multitenant: bool = CreateCollectionDefaults.multitenant,
+        auto_tenant_creation: bool = CreateCollectionDefaults.auto_tenant_creation,
+        auto_tenant_activation: bool = CreateCollectionDefaults.auto_tenant_activation,
+        force_auto_schema: bool = CreateCollectionDefaults.force_auto_schema,
+        shards: int = CreateCollectionDefaults.shards,
+        vectorizer: Optional[str] = CreateCollectionDefaults.vectorizer,
+        replication_deletion_strategy: Optional[
+            str
+        ] = CreateCollectionDefaults.replication_deletion_strategy,
     ) -> None:
 
         if self.client.collections.exists(collection):
@@ -197,14 +207,20 @@ class CollectionManager:
 
     def update_collection(
         self,
-        collection: str,
-        description: Optional[str],
-        vector_index: Optional[str],
-        training_limit: int,
-        async_enabled: Optional[bool],
-        auto_tenant_creation: Optional[bool],
-        auto_tenant_activation: Optional[bool],
-        replication_deletion_strategy: Optional[str],
+        collection: str = UpdateCollectionDefaults.collection,
+        description: Optional[str] = UpdateCollectionDefaults.description,
+        vector_index: Optional[str] = UpdateCollectionDefaults.vector_index,
+        training_limit: int = UpdateCollectionDefaults.training_limit,
+        async_enabled: Optional[bool] = UpdateCollectionDefaults.async_enabled,
+        auto_tenant_creation: Optional[
+            bool
+        ] = UpdateCollectionDefaults.auto_tenant_creation,
+        auto_tenant_activation: Optional[
+            bool
+        ] = UpdateCollectionDefaults.auto_tenant_activation,
+        replication_deletion_strategy: Optional[
+            str
+        ] = UpdateCollectionDefaults.replication_deletion_strategy,
     ) -> None:
 
         if not self.client.collections.exists(collection):
@@ -284,7 +300,11 @@ class CollectionManager:
 
         click.echo(f"Collection '{collection}' modified successfully in Weaviate.")
 
-    def delete_collection(self, collection: str, all: bool) -> None:
+    def delete_collection(
+        self,
+        collection: str = DeleteCollectionDefaults.collection,
+        all: bool = DeleteCollectionDefaults.all,
+    ) -> None:
         if all:
             collections: List[str] = self.client.collections.list_all()
             for collection in collections:

--- a/weaviate_cli/managers/data_manager.py
+++ b/weaviate_cli/managers/data_manager.py
@@ -12,7 +12,12 @@ from typing import Dict, List, Optional, Union, Any
 import weaviate.classes.config as wvc
 from weaviate.collections import Collection
 from datetime import datetime, timedelta
-import sys
+from weaviate_cli.defaults import (
+    CreateDataDefaults,
+    QueryDataDefaults,
+    UpdateDataDefaults,
+    DeleteDataDefaults,
+)
 import importlib.resources as resources
 from pathlib import Path
 
@@ -187,14 +192,14 @@ class DataManager:
             )
             return num_objects_inserted
 
-    def ingest_data(
+    def create_data(
         self,
-        collection: Optional[str],
-        limit: int,
-        consistency_level: str,
-        randomize: bool,
-        auto_tenants: int,
-        vector_dimensions: Optional[int] = 1536,
+        collection: Optional[str] = CreateDataDefaults.collection,
+        limit: int = CreateDataDefaults.limit,
+        consistency_level: str = CreateDataDefaults.consistency_level,
+        randomize: bool = CreateDataDefaults.randomize,
+        auto_tenants: int = CreateDataDefaults.auto_tenants,
+        vector_dimensions: Optional[int] = CreateDataDefaults.vector_dimensions,
     ) -> None:
 
         if not self.client.collections.exists(collection):
@@ -321,7 +326,11 @@ class DataManager:
             return found_objects
 
     def update_data(
-        self, collection: str, limit: int, consistency_level: str, randomize: bool
+        self,
+        collection: str = UpdateDataDefaults.collection,
+        limit: int = UpdateDataDefaults.limit,
+        consistency_level: str = UpdateDataDefaults.consistency_level,
+        randomize: bool = UpdateDataDefaults.randomize,
     ) -> None:
 
         if not self.client.collections.exists(collection):
@@ -398,10 +407,10 @@ class DataManager:
 
     def delete_data(
         self,
-        collection: str,
-        limit: int,
-        consistency_level: str,
-        uuid: Optional[str] = None,
+        collection: str = DeleteDataDefaults.collection,
+        limit: int = DeleteDataDefaults.limit,
+        consistency_level: str = DeleteDataDefaults.consistency_level,
+        uuid: Optional[str] = DeleteDataDefaults.uuid,
     ) -> None:
 
         if not self.client.collections.exists(collection):
@@ -512,12 +521,12 @@ class DataManager:
 
     def query_data(
         self,
-        collection: str,
-        search_type: str,
-        query: str,
-        consistency_level: str,
-        limit: int,
-        properties: str,
+        collection: str = QueryDataDefaults.collection,
+        search_type: str = QueryDataDefaults.search_type,
+        query: str = QueryDataDefaults.query,
+        consistency_level: str = QueryDataDefaults.consistency_level,
+        limit: int = QueryDataDefaults.limit,
+        properties: str = QueryDataDefaults.properties,
     ) -> None:
 
         if not self.client.collections.exists(collection):

--- a/weaviate_cli/managers/shard_manager.py
+++ b/weaviate_cli/managers/shard_manager.py
@@ -1,4 +1,9 @@
+from typing import Optional
 from weaviate import WeaviateClient
+from weaviate_cli.defaults import (
+    GetShardsDefaults,
+    UpdateShardsDefaults,
+)
 import click
 
 
@@ -6,7 +11,9 @@ class ShardManager:
     def __init__(self, client: WeaviateClient):
         self.client = client
 
-    def get_shards(self, collection: str) -> None:
+    def get_shards(
+        self, collection: Optional[str] = GetShardsDefaults.collection
+    ) -> None:
         """
         Retrieve and display shard information for a given collection.
 
@@ -45,7 +52,13 @@ class ShardManager:
             f"Shard Name: {shard_name}, Status: {vector_indexing_status}, Queue Length: {vector_queue_length}"
         )
 
-    def update_shards(self, status: str, collection: str, shards: str, all: bool):
+    def update_shards(
+        self,
+        status: str = UpdateShardsDefaults.status,
+        collection: Optional[str] = UpdateShardsDefaults.collection,
+        shards: Optional[str] = UpdateShardsDefaults.shards,
+        all: bool = UpdateShardsDefaults.all,
+    ):
         """
         Update the status of shards in a collection.
 

--- a/weaviate_cli/managers/tenant_manager.py
+++ b/weaviate_cli/managers/tenant_manager.py
@@ -3,6 +3,12 @@ import semver
 
 from weaviate import WeaviateClient
 from weaviate.collections.classes.tenants import TenantActivityStatus, Tenant
+from weaviate_cli.defaults import (
+    CreateTenantsDefaults,
+    UpdateTenantsDefaults,
+    DeleteTenantsDefaults,
+    GetTenantsDefaults,
+)
 
 
 class TenantManager:
@@ -10,7 +16,11 @@ class TenantManager:
         self.client = client
 
     def create_tenants(
-        self, collection: str, tenant_suffix: str, number_tenants: int, state: str
+        self,
+        collection: str = CreateTenantsDefaults.collection,
+        tenant_suffix: str = CreateTenantsDefaults.tenant_suffix,
+        number_tenants: int = CreateTenantsDefaults.number_tenants,
+        state: str = CreateTenantsDefaults.state,
     ) -> None:
         """
         Create tenants for a given collection in Weaviate.
@@ -92,7 +102,10 @@ class TenantManager:
         )
 
     def delete_tenants(
-        self, collection: str, tenant_suffix: str, number_tenants: int
+        self,
+        collection: str = DeleteTenantsDefaults.collection,
+        tenant_suffix: str = DeleteTenantsDefaults.tenant_suffix,
+        number_tenants: int = DeleteTenantsDefaults.number_tenants,
     ) -> None:
         """
         Delete tenants for a given collection in Weaviate.
@@ -168,7 +181,11 @@ class TenantManager:
 
         click.echo(f"{number_tenants} tenants deleted")
 
-    def get_tenants(self, collection: str, verbose: bool) -> dict:
+    def get_tenants(
+        self,
+        collection: str = GetTenantsDefaults.collection,
+        verbose: bool = GetTenantsDefaults.verbose,
+    ) -> dict:
         """
         Retrieve tenants for a given collection in Weaviate.
 
@@ -214,7 +231,11 @@ class TenantManager:
         return tenants
 
     def update_tenants(
-        self, collection: str, tenant_suffix: str, number_tenants: int, state: str
+        self,
+        collection: str = UpdateTenantsDefaults.collection,
+        tenant_suffix: str = UpdateTenantsDefaults.tenant_suffix,
+        number_tenants: int = UpdateTenantsDefaults.number_tenants,
+        state: str = UpdateTenantsDefaults.state,
     ) -> None:
         """
         Updates the activity status of a specified number of tenants in a collection.


### PR DESCRIPTION
This commit adds a defaults class in which all the default values for each of the methods are defined. This way we don't need to pass always all the arguments when importing some of the managers functions and at the same time keep all defaults in a central place.

Also, it renames de ingest_data function into create_data to keep consistent with the rest of create functions.