### PR TITLE
Enable time based resolution configuration and create object with UUID

### DIFF
--- a/weaviate_cli/commands/update.py
+++ b/weaviate_cli/commands/update.py
@@ -65,7 +65,9 @@ def update() -> None:
 @click.option(
     "--replication_deletion_strategy",
     default=UpdateCollectionDefaults.replication_deletion_strategy,
-    type=click.Choice(["delete_on_conflict", "no_automated_resolution"]),
+    type=click.Choice(
+        ["delete_on_conflict", "no_automated_resolution", "time_based_resolution"]
+    ),
     help="Replication deletion strategy.",
 )
 @click.pass_context

--- a/weaviate_cli/managers/collection_manager.py
+++ b/weaviate_cli/managers/collection_manager.py
@@ -170,6 +170,7 @@ class CollectionManager:
         rds_map = {
             "delete_on_conflict": wvc.ReplicationDeletionStrategy.DELETE_ON_CONFLICT,
             "no_automated_resolution": wvc.ReplicationDeletionStrategy.NO_AUTOMATED_RESOLUTION,
+            "time_based_resolution": wvc.ReplicationDeletionStrategy.TIME_BASED_RESOLUTION,
         }
 
         try:
@@ -260,6 +261,7 @@ class CollectionManager:
         rds_map = {
             "delete_on_conflict": wvc.ReplicationDeletionStrategy.DELETE_ON_CONFLICT,
             "no_automated_resolution": wvc.ReplicationDeletionStrategy.NO_AUTOMATED_RESOLUTION,
+            "time_based_resolution": wvc.ReplicationDeletionStrategy.TIME_BASED_RESOLUTION,
         }
         mt = col_obj.config.get().multi_tenancy_config.enabled
         auto_tenant_creation = (

--- a/weaviate_cli/managers/data_manager.py
+++ b/weaviate_cli/managers/data_manager.py
@@ -145,6 +145,7 @@ class DataManager:
         cl: wvc.ConsistencyLevel,
         randomize: bool,
         vector_dimensions: Optional[int] = 1536,
+        uuid: Optional[str] = None,
     ) -> int:
         if randomize:
             counter = 0
@@ -169,6 +170,7 @@ class DataManager:
                 for obj in data_objects:
                     batch.add_object(
                         properties=obj,
+                        uuid=uuid,
                         vector=(
                             2 * np.random.rand(1, vector_dimensions)[0] - 1
                         ).tolist(),
@@ -200,6 +202,7 @@ class DataManager:
         randomize: bool = CreateDataDefaults.randomize,
         auto_tenants: int = CreateDataDefaults.auto_tenants,
         vector_dimensions: Optional[int] = CreateDataDefaults.vector_dimensions,
+        uuid: Optional[str] = None,
     ) -> None:
 
         if not self.client.collections.exists(collection):
@@ -252,6 +255,7 @@ class DataManager:
                     cl_map[consistency_level],
                     randomize,
                     vector_dimensions,
+                    uuid,
                 )
             else:
                 click.echo(f"Processing tenant '{tenant}'")
@@ -261,6 +265,7 @@ class DataManager:
                     cl_map[consistency_level],
                     randomize,
                     vector_dimensions,
+                    uuid,
                 )
 
             if ret == -1:


### PR DESCRIPTION
The PR adds support to TIME BASED RESOLUTION configuration at class level.

It also adds the option to set an uuid when creating one object.

Depends on https://github.com/weaviate/weaviate-python-client/pull/1364