### PR TITLE
GitHub Actions: Add Python 3.13 to the testing

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ "3.9", "3.10", "3.11", "3.12" ]
+        version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ "3.9", "3.10", "3.11", "3.12" ]
+        version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4


### PR DESCRIPTION
Let's test on Python 3.13.1.
```diff
      matrix:
-       version: [ "3.9", "3.10", "3.11", "3.12" ]
+       version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
```
https://devguide.python.org/versions/#supported-versions

I agree to the CLA.