### PR TITLE
Do not add empty property and add extra check of failed objects

### DIFF
--- a/weaviate_cli/managers/data_manager.py
+++ b/weaviate_cli/managers/data_manager.py
@@ -57,7 +57,7 @@ class DataManager:
                         added_obj = {}
                         for prop in properties:
                             prop_name = PROPERTY_NAME_MAPPING.get(prop.name, prop.name)
-                            if prop_name in obj:
+                            if prop_name in obj and obj[prop_name] != "":
                                 added_obj[prop.name] = self.__convert_property_value(
                                     obj[prop_name], prop.data_type
                                 )
@@ -183,6 +183,7 @@ class DataManager:
                         f"Failed to add object with UUID {failed_object.original_uuid}: {failed_object.message}"
                     )
                 return -1
+
             print(f"Inserted {counter} objects into class '{collection.name}'")
             return counter
         else:


### PR DESCRIPTION
The movies.json dataset contains elements with empty properties. This PR avoids adding those properties of those elements.

Additionally, the failure of a data importing might be reported only to the client, so check for failed objects in the client object as well.