### PR TITLE
Add new improvements for tenants and data.

### DIFF
--- a/weaviate_cli/commands/create.py
+++ b/weaviate_cli/commands/create.py
@@ -183,7 +183,7 @@ def create_collection_cli(
 @click.option(
     "--tenant_suffix",
     default=CreateTenantsDefaults.tenant_suffix,
-    help="The suffix to add to the tenant name (default: 'Tenant--').",
+    help="The suffix to add to the tenant name (default: 'Tenant-').",
 )
 @click.option(
     "--number_tenants",
@@ -191,12 +191,20 @@ def create_collection_cli(
     help="Number of tenants to create (default: 100).",
 )
 @click.option(
+    "--tenant_batch_size",
+    default=CreateTenantsDefaults.tenant_batch_size,
+    type=int,
+    help="Number of tenants to create in each batch (default: None, all tenants will be created in one batch).",
+)
+@click.option(
     "--state",
     default=CreateTenantsDefaults.state,
     type=click.Choice(["hot", "active", "cold", "inactive", "frozen", "offloaded"]),
 )
 @click.pass_context
-def create_tenants_cli(ctx, collection, tenant_suffix, number_tenants, state):
+def create_tenants_cli(
+    ctx, collection, tenant_suffix, number_tenants, tenant_batch_size, state
+):
     """Create tenants in Weaviate."""
 
     client = None
@@ -208,6 +216,7 @@ def create_tenants_cli(ctx, collection, tenant_suffix, number_tenants, state):
             collection=collection,
             tenant_suffix=tenant_suffix,
             number_tenants=number_tenants,
+            tenant_batch_size=tenant_batch_size,
             state=state,
         )
     except Exception as e:
@@ -302,6 +311,16 @@ def create_backup_cli(ctx, backend, backup_id, include, exclude, wait, cpu_for_b
     help="Number of tenants for which we will send data. NOTE: Requires class with --auto_tenant_creation (default: 0).",
 )
 @click.option(
+    "--tenants",
+    default=None,
+    help="Comma separated list of tenants to send data to.",
+)
+@click.option(
+    "--tenant_suffix",
+    default=CreateTenantsDefaults.tenant_suffix,
+    help="The suffix to add to the tenant name (default: 'Tenant-'). Only used if --auto_tenants is provided.",
+)
+@click.option(
     "--vector_dimensions",
     default=CreateDataDefaults.vector_dimensions,
     help="Number of vector dimensions to be used when the data is randomized.",
@@ -319,6 +338,8 @@ def create_data_cli(
     consistency_level,
     randomize,
     auto_tenants,
+    tenants,
+    tenant_suffix,
     vector_dimensions,
     uuid,
 ):
@@ -349,8 +370,10 @@ def create_data_cli(
             consistency_level=consistency_level,
             randomize=randomize,
             auto_tenants=auto_tenants,
+            tenants_list=tenants.split(",") if tenants else None,
             vector_dimensions=vector_dimensions,
             uuid=uuid,
+            tenant_suffix=tenant_suffix,
         )
     except Exception as e:
         click.echo(f"Error: {e}")

--- a/weaviate_cli/commands/delete.py
+++ b/weaviate_cli/commands/delete.py
@@ -60,7 +60,7 @@ def delete_collection_cli(ctx: click.Context, collection: str, all: bool) -> Non
 @click.option(
     "--tenant_suffix",
     default=DeleteTenantsDefaults.tenant_suffix,
-    help="The suffix to add to the tenant name (default: 'Tenant--').",
+    help="The suffix to add to the tenant name (default: 'Tenant-').",
 )
 @click.option(
     "--number_tenants",
@@ -111,12 +111,17 @@ def delete_tenants_cli(
     help="Consistency level (default: 'quorum').",
 )
 @click.option(
+    "--tenants",
+    default=None,
+    help="Comma separated list of tenants to delete data from.",
+)
+@click.option(
     "--uuid",
     default=DeleteDataDefaults.uuid,
     help="UUID of the oject to be deleted. If provided, --limit will be ignored.",
 )
 @click.pass_context
-def delete_data_cli(ctx, collection, limit, consistency_level, uuid):
+def delete_data_cli(ctx, collection, limit, consistency_level, tenants, uuid):
     """Delete data from a collection in Weaviate."""
 
     client = None
@@ -128,6 +133,7 @@ def delete_data_cli(ctx, collection, limit, consistency_level, uuid):
             collection=collection,
             limit=limit,
             consistency_level=consistency_level,
+            tenants_list=tenants.split(",") if tenants else None,
             uuid=uuid,
         )
     except Exception as e:

--- a/weaviate_cli/commands/update.py
+++ b/weaviate_cli/commands/update.py
@@ -121,7 +121,7 @@ def update_collection_cli(
 @click.option(
     "--tenant_suffix",
     default=UpdateTenantsDefaults.tenant_suffix,
-    help="The suffix to add to the tenant name (default: 'Tenant--').",
+    help="The suffix to add to the tenant name (default: 'Tenant-').",
 )
 @click.option(
     "--number_tenants",

--- a/weaviate_cli/defaults.py
+++ b/weaviate_cli/defaults.py
@@ -30,6 +30,8 @@ PERMISSION_HELP_STRING = (
     "  --permission read_cluster"
 )
 
+MAX_OBJECTS_PER_BATCH = 5000
+
 
 @dataclass
 class CreateCollectionDefaults:
@@ -51,8 +53,9 @@ class CreateCollectionDefaults:
 @dataclass
 class CreateTenantsDefaults:
     collection: str = "Movies"
-    tenant_suffix: str = "Tenant--"
+    tenant_suffix: str = "Tenant-"
     number_tenants: int = 100
+    tenant_batch_size: Optional[int] = None
     state: str = "active"
 
 
@@ -97,7 +100,7 @@ class DeleteCollectionDefaults:
 @dataclass
 class DeleteTenantsDefaults:
     collection: str = "Movies"
-    tenant_suffix: str = "Tenant--"
+    tenant_suffix: str = "Tenant-"
     number_tenants: int = 100
 
 
@@ -183,7 +186,7 @@ class UpdateCollectionDefaults:
 @dataclass
 class UpdateTenantsDefaults:
     collection: str = "Movies"
-    tenant_suffix: str = "Tenant--"
+    tenant_suffix: str = "Tenant-"
     number_tenants: int = 100
     state: str = "active"
 


### PR DESCRIPTION
* Allow creating tenants in batches.
* Change default tenant name from `Tenant--` to `Tenant-`.
* Allow creating more tenants when the collection already had some tenants on it.
* Add new option to pass a list of comma-separated tenants when adding objects. Only those tenants will be used. If not passed, the same number of objects will be added to all tenants.
* Same (option to pass tenants), but for deletes.
* Improve deletes into using batches, as well as supporting the deletion of large number of objects (more than 10000) whihc was failing before.

Fixes: #115
