### PR TITLE
Support for RF update and use connect_to_weaviate_cloud.

### DIFF
--- a/test/unittests/test_managers/test_collection_manager.py
+++ b/test/unittests/test_managers/test_collection_manager.py
@@ -146,6 +146,7 @@ def test_update_collection(mock_client):
         description="Updated description",
         vector_index="hnsw",
         async_enabled=True,
+        replication_factor=5,
         auto_tenant_creation=True,
         auto_tenant_activation=True,
         replication_deletion_strategy="delete_on_conflict",
@@ -157,7 +158,7 @@ def test_update_collection(mock_client):
         == "Updated description"
     )
     assert (
-        mock_collection.config.update.call_args.kwargs["replication_config"].factor == 3
+        mock_collection.config.update.call_args.kwargs["replication_config"].factor == 5
     )
     assert (
         mock_collection.config.update.call_args.kwargs[

--- a/weaviate_cli/commands/update.py
+++ b/weaviate_cli/commands/update.py
@@ -39,6 +39,12 @@ def update() -> None:
     help="Enable async (default: None).",
 )
 @click.option(
+    "--replication_factor",
+    default=UpdateCollectionDefaults.replication_factor,
+    type=int,
+    help="Replication factor (default: None).",
+)
+@click.option(
     "--vector_index",
     default=UpdateCollectionDefaults.vector_index,
     type=click.Choice(
@@ -81,6 +87,7 @@ def update_collection_cli(
     ctx: click.Context,
     collection: str,
     async_enabled: Optional[bool],
+    replication_factor: Optional[int],
     vector_index: Optional[str],
     description: Optional[str],
     training_limit: int,
@@ -98,6 +105,7 @@ def update_collection_cli(
         collection_man.update_collection(
             collection=collection,
             async_enabled=async_enabled,
+            replication_factor=replication_factor,
             vector_index=vector_index,
             description=description,
             training_limit=training_limit,

--- a/weaviate_cli/defaults.py
+++ b/weaviate_cli/defaults.py
@@ -187,6 +187,7 @@ class RestoreBackupDefaults:
 class UpdateCollectionDefaults:
     collection: str = "Movies"
     async_enabled: Optional[bool] = None
+    replication_factor: Optional[int] = None
     vector_index: Optional[str] = None
     description: Optional[str] = None
     training_limit: int = 10000

--- a/weaviate_cli/managers/collection_manager.py
+++ b/weaviate_cli/managers/collection_manager.py
@@ -274,6 +274,7 @@ class CollectionManager:
         vector_index: Optional[str] = UpdateCollectionDefaults.vector_index,
         training_limit: int = UpdateCollectionDefaults.training_limit,
         async_enabled: Optional[bool] = UpdateCollectionDefaults.async_enabled,
+        replication_factor: Optional[int] = UpdateCollectionDefaults.replication_factor,
         auto_tenant_creation: Optional[
             bool
         ] = UpdateCollectionDefaults.auto_tenant_creation,
@@ -316,7 +317,11 @@ class CollectionManager:
         }
 
         col_obj: Collection = self.client.collections.get(collection)
-        rf = col_obj.config.get().replication_config.factor
+        rf = (
+            replication_factor
+            if replication_factor is not None
+            else col_obj.config.get().replication_config.factor
+        )
         rds_map = {
             "delete_on_conflict": wvc.ReplicationDeletionStrategy.DELETE_ON_CONFLICT,
             "no_automated_resolution": wvc.ReplicationDeletionStrategy.NO_AUTOMATED_RESOLUTION,

--- a/weaviate_cli/managers/config_manager.py
+++ b/weaviate_cli/managers/config_manager.py
@@ -118,7 +118,7 @@ class ConfigManager:
                 headers=self.config["headers"] if "headers" in self.config else None,
             )
         elif self.config["host"].endswith("weaviate.cloud"):
-            return weaviate.connect_to_wcs(
+            return weaviate.connect_to_weaviate_cloud(
                 cluster_url=self.config["host"],
                 auth_credentials=auth_config,
                 headers=self.config["headers"] if "headers" in self.config else None,


### PR DESCRIPTION
This PR replaces the use of connect_to_wcs method into using connect_to_weaviate_cloud instead as it's usage is not encouraged.

Also, it adds support in the update collection to modify the replication factor.