### PR TITLE
Support collection aliases in all data operations

### DIFF
--- a/.claude/skills/operating-weaviate-cli/SKILL.md
+++ b/.claude/skills/operating-weaviate-cli/SKILL.md
@@ -183,6 +183,8 @@ Key query options: `--properties "title,keywords"`, `--tenants "T1"`, `--target_
 
 **Note**: `--consistency_level` values must be **lowercase**: `one`, `quorum`, `all` (not `ONE`, `QUORUM`, `ALL`).
 
+**Alias support**: The `--collection` flag accepts collection aliases in all data commands. If the name isn't a direct collection, the CLI checks the alias list automatically.
+
 See [references/data.md](references/data.md) and [references/search.md](references/search.md).
 
 ### Tenants
@@ -213,7 +215,7 @@ weaviate-cli restore backup --backend s3 --backup_id my-backup --wait --json
 weaviate-cli cancel backup --backend s3 --backup_id my-backup --json
 ```
 
-Backends: `s3`, `gcs`, `filesystem`. Options: `--include`, `--exclude`, `--wait`, `--cpu_for_backup N`
+Backends: `s3`, `gcs`, `filesystem`. Options: `--include`, `--exclude`, `--wait`, `--cpu_for_backup N`, `--override-alias`
 
 See [references/backups.md](references/backups.md).
 

--- a/.claude/skills/operating-weaviate-cli/references/backups.md
+++ b/.claude/skills/operating-weaviate-cli/references/backups.md
@@ -23,6 +23,7 @@ weaviate-cli get backup --backend s3 --backup_id my-backup --restore --json
 ```bash
 weaviate-cli restore backup --backend s3 --backup_id my-backup --wait --json
 weaviate-cli restore backup --backend s3 --backup_id my-backup --include "Movies" --wait --json
+weaviate-cli restore backup --backend s3 --backup_id my-backup --override-alias --wait --json
 ```
 
 ## Cancel Backup
@@ -44,6 +45,7 @@ weaviate-cli cancel backup --backend s3 --backup_id my-backup --json
 - `--backend`, `--backup_id` -- Same as create
 - `--include`, `--exclude` -- Filter which collections to restore
 - `--wait` -- Wait for completion
+- `--override-alias` -- Override alias conflicts during restore. Use when the backup contains a collection with an alias that differs from the current cluster state (e.g., the backup had alias `Movies` pointing to `Movies_v1`, but the cluster now has `Movies` pointing to `Movies_v2`). Without this flag, the restore will fail due to the alias conflict.
 
 ## Prerequisites
 

--- a/.claude/skills/operating-weaviate-cli/references/data.md
+++ b/.claude/skills/operating-weaviate-cli/references/data.md
@@ -50,6 +50,19 @@ weaviate-cli delete data --collection "Movies" --tenants "T1,T2" --limit 50 --js
 3. **For multi-tenant data ingestion:** tenants must be in `hot`/`active` state
 4. **For vectorizer-based ingestion (non-randomize):** the collection uses a built-in dataset; vectorizer API keys may be needed
 
+## Using Aliases
+
+The `--collection` flag accepts aliases in all data commands (`create data`, `query data`, `update data`, `delete data`). If the given name doesn't match a collection directly, the CLI checks the alias list and resolves it transparently.
+
+```bash
+# Create an alias, then use it for data operations
+weaviate-cli create alias MyAlias Movies --json
+weaviate-cli create data --collection MyAlias --limit 100 --randomize --json
+weaviate-cli query data --collection MyAlias --search_type fetch --limit 10 --json
+weaviate-cli update data --collection MyAlias --limit 50 --randomize --json
+weaviate-cli delete data --collection MyAlias --limit 50 --json
+```
+
 ## Notes
 
 - `--randomize` generates synthetic data with random vectors -- useful for testing

--- a/test/unittests/test_managers/test_data_manager.py
+++ b/test/unittests/test_managers/test_data_manager.py
@@ -223,6 +223,118 @@ class TestResolveTenants:
         assert result == []
 
 
+# ---------------------------------------------------------------------------
+# Alias resolution in data operations
+# ---------------------------------------------------------------------------
+
+
+class TestAliasResolution:
+    """Unit tests for alias resolution in create/update/delete/query data."""
+
+    def _setup_alias_mock(self, mock_client, alias_name="MyAlias"):
+        """Set up a mock client where collection doesn't exist but alias does."""
+        mock_collections = MagicMock()
+        mock_collections.exists.return_value = False
+        mock_client.collections = mock_collections
+
+        mock_alias = MagicMock()
+        mock_alias.list_all.return_value = {alias_name: MagicMock()}
+        mock_client.alias = mock_alias
+
+        mock_collection = MagicMock()
+        mock_collection.config.get.return_value = MagicMock(
+            multi_tenancy_config=MagicMock(
+                enabled=False,
+                auto_tenant_creation=False,
+                auto_tenant_activation=False,
+            )
+        )
+        mock_client.collections.get.return_value = mock_collection
+        return mock_collection
+
+    def test_create_data_with_alias(self, mock_client):
+        self._setup_alias_mock(mock_client)
+        manager = DataManager(mock_client)
+        manager.create_data(collection="MyAlias", limit=10, randomize=True)
+        mock_client.collections.get.assert_called_once_with("MyAlias")
+
+    def test_update_data_with_alias(self, mock_client):
+        self._setup_alias_mock(mock_client)
+        manager = DataManager(mock_client)
+        manager.update_data(collection="MyAlias", limit=10, randomize=True)
+        mock_client.collections.get.assert_called_once_with("MyAlias")
+
+    def test_delete_data_with_alias(self, mock_client):
+        col = self._setup_alias_mock(mock_client)
+        col.config.get.return_value.multi_tenancy_config.enabled = False
+        # delete_data iterates objects, mock the iterator
+        col.iterator.return_value = iter([])
+        manager = DataManager(mock_client)
+        manager.delete_data(collection="MyAlias", limit=10)
+        mock_client.collections.get.assert_called_once_with("MyAlias")
+
+    def test_query_data_with_alias(self, mock_client):
+        col = self._setup_alias_mock(mock_client)
+        col.config.get.return_value.multi_tenancy_config.enabled = False
+        col.query.fetch_objects.return_value = MagicMock(objects=[])
+        manager = DataManager(mock_client)
+        manager.query_data(collection="MyAlias", search_type="fetch", limit=5)
+        mock_client.collections.get.assert_called_once_with("MyAlias")
+
+    def _setup_not_found_mock(self, mock_client):
+        """Set up a mock client where neither collection nor alias exists."""
+        mock_collections = MagicMock()
+        mock_collections.exists.return_value = False
+        mock_client.collections = mock_collections
+        mock_alias = MagicMock()
+        mock_alias.list_all.return_value = {}
+        mock_client.alias = mock_alias
+
+    def test_create_data_not_collection_not_alias_raises(self, mock_client):
+        self._setup_not_found_mock(mock_client)
+        manager = DataManager(mock_client)
+        with pytest.raises(Exception, match="does not exist"):
+            manager.create_data(collection="NonExistent", limit=10, randomize=True)
+
+    def test_update_data_not_collection_not_alias_raises(self, mock_client):
+        self._setup_not_found_mock(mock_client)
+        manager = DataManager(mock_client)
+        with pytest.raises(Exception, match="does not exist"):
+            manager.update_data(collection="NonExistent", limit=10, randomize=True)
+
+    def test_delete_data_not_collection_not_alias_raises(self, mock_client):
+        self._setup_not_found_mock(mock_client)
+        manager = DataManager(mock_client)
+        with pytest.raises(Exception, match="does not exist"):
+            manager.delete_data(collection="NonExistent", limit=10)
+
+    def test_query_data_not_collection_not_alias_raises(self, mock_client):
+        self._setup_not_found_mock(mock_client)
+        manager = DataManager(mock_client)
+        with pytest.raises(Exception, match="does not exist"):
+            manager.query_data(collection="NonExistent", search_type="fetch", limit=5)
+
+    def test_create_data_direct_collection_skips_alias_check(self, mock_client):
+        """When collection exists directly, alias.list_all should not be called."""
+        mock_collections = MagicMock()
+        mock_collections.exists.return_value = True
+        mock_client.collections = mock_collections
+        mock_alias = MagicMock()
+        mock_client.alias = mock_alias
+        mock_collection = MagicMock()
+        mock_collection.config.get.return_value = MagicMock(
+            multi_tenancy_config=MagicMock(
+                enabled=False,
+                auto_tenant_creation=False,
+                auto_tenant_activation=False,
+            )
+        )
+        mock_client.collections.get.return_value = mock_collection
+        manager = DataManager(mock_client)
+        manager.create_data(collection="DirectCollection", limit=10, randomize=True)
+        mock_client.alias.list_all.assert_not_called()
+
+
 def test_ingest_data(mock_client):
     manager = DataManager(mock_client)
     mock_collections = MagicMock()

--- a/weaviate_cli/commands/restore.py
+++ b/weaviate_cli/commands/restore.py
@@ -39,10 +39,17 @@ def restore() -> None:
     help="Collection to exclude in backup (default: None).",
 )
 @click.option(
+    "--override-alias",
+    is_flag=True,
+    help="Override the alias of the collection (default: False).",
+)
+@click.option(
     "--json", "json_output", is_flag=True, default=False, help="Output in JSON format."
 )
 @click.pass_context
-def restore_backup_cli(ctx, backend, include, exclude, backup_id, wait, json_output):
+def restore_backup_cli(
+    ctx, backend, include, exclude, backup_id, wait, override_alias, json_output
+):
     """Restore a backup in Weaviate."""
 
     client = None
@@ -55,6 +62,7 @@ def restore_backup_cli(ctx, backend, include, exclude, backup_id, wait, json_out
             include=include,
             exclude=exclude,
             wait=wait,
+            override_alias=override_alias,
             json_output=json_output,
         )
     except Exception as e:

--- a/weaviate_cli/defaults.py
+++ b/weaviate_cli/defaults.py
@@ -237,6 +237,7 @@ class RestoreBackupDefaults:
     wait: bool = False
     include: Optional[str] = None
     exclude: Optional[str] = None
+    override_alias: bool = False
 
 
 @dataclass

--- a/weaviate_cli/managers/backup_manager.py
+++ b/weaviate_cli/managers/backup_manager.py
@@ -14,7 +14,7 @@ from weaviate_cli.defaults import (
 
 class BackupManager:
     def __init__(self, client: WeaviateClient) -> None:
-        self.client = client
+        self.client: WeaviateClient = client
 
     def create_backup(
         self,
@@ -81,6 +81,7 @@ class BackupManager:
         include: Optional[str] = RestoreBackupDefaults.include,
         exclude: Optional[str] = RestoreBackupDefaults.exclude,
         wait: bool = RestoreBackupDefaults.wait,
+        override_alias: bool = RestoreBackupDefaults.override_alias,
         json_output: bool = False,
     ) -> None:
 
@@ -89,6 +90,7 @@ class BackupManager:
             backend=backend,
             include_collections=include.split(",") if include else None,
             exclude_collections=exclude.split(",") if exclude else None,
+            overwrite_alias=override_alias,
             wait_for_completion=wait,
         )
 

--- a/weaviate_cli/managers/data_manager.py
+++ b/weaviate_cli/managers/data_manager.py
@@ -569,19 +569,11 @@ class DataManager:
         file_name: str,
         cl: wvc.ConsistencyLevel,
         num_objects: Optional[int] = None,
-        alias: Optional[str] = None,
         json_output: bool = False,
     ) -> int:
         counter = 0
-        if alias is None:
-            properties: List[wvc.Property] = collection.config.get().properties
-        else:
-            collection_from_alias = self.client.alias.get(alias_name=alias).collection
-            properties: List[wvc.Property] = (
-                self.client.collections.get(collection_from_alias)
-                .config.get()
-                .properties
-            )
+
+        properties: List[wvc.Property] = collection.config.get().properties
 
         try:
             with (
@@ -659,7 +651,6 @@ class DataManager:
         dynamic_batch: bool = False,
         batch_size: int = 1000,
         concurrent_requests: int = MAX_WORKERS,
-        alias: Optional[str] = None,
         json_output: bool = False,
     ) -> Collection:
         if randomize:
@@ -668,13 +659,7 @@ class DataManager:
             start_time = time.time()
 
             # Determine vector dimensions based on vectorizer
-            if alias is None:
-                config = collection.config.get()
-            else:
-                collection_from_alias = self.client.alias.get(
-                    alias_name=alias
-                ).collection
-                config = self.client.collections.get(collection_from_alias).config.get()
+            config = collection.config.get()
 
             if not config.vectorizer and config.vector_config:
                 named_vectors = list(config.vector_config.keys())
@@ -729,7 +714,7 @@ class DataManager:
             if not json_output:
                 click.echo(f"Importing {num_objects} objects from Movies dataset")
             num_objects_inserted = self.__import_json(
-                collection, "movies.json", cl, num_objects, alias, json_output=json_output
+                collection, "movies.json", cl, num_objects, json_output=json_output
             )
             if not json_output:
                 print(
@@ -837,16 +822,12 @@ class DataManager:
         json_output: bool = False,
     ) -> Collection:
 
-        alias = None
         if not self.client.collections.exists(collection):
             alias_list = self.client.alias.list_all()
             if collection not in alias_list.keys():
                 raise Exception(
                     f"Class '{collection}' does not exist in Weaviate. Create first using <create class> command"
                 )
-            else:
-                alias = collection
-                collection = str(alias_list[collection].collection)
 
         col: Collection = self.client.collections.get(collection)
         mt_config = col.config.get().multi_tenancy_config
@@ -883,9 +864,7 @@ class DataManager:
             if tenant == "None":
                 initial_length = len(col)
                 collection = self.__ingest_data(
-                    collection=(
-                        col if alias is None else self.client.collections.get(alias)
-                    ),
+                    collection=col,
                     num_objects=limit,
                     cl=cl_map[consistency_level],
                     randomize=randomize,
@@ -897,7 +876,6 @@ class DataManager:
                     dynamic_batch=dynamic_batch,
                     batch_size=batch_size,
                     concurrent_requests=concurrent_requests,
-                    alias=alias,
                     json_output=json_output,
                 )
                 after_length = len(col)
@@ -922,11 +900,7 @@ class DataManager:
                 if not json_output:
                     click.echo(f"Processing objects for tenant '{tenant}'")
                 collection = self.__ingest_data(
-                    collection=(
-                        col.with_tenant(tenant)
-                        if alias is None
-                        else self.client.collections.get(alias).with_tenant(tenant)
-                    ),
+                    collection=col.with_tenant(tenant),
                     num_objects=limit,
                     cl=cl_map[consistency_level],
                     randomize=randomize,
@@ -938,7 +912,6 @@ class DataManager:
                     dynamic_batch=dynamic_batch,
                     batch_size=batch_size,
                     concurrent_requests=concurrent_requests,
-                    alias=alias,
                     json_output=json_output,
                 )
                 after_length = len(col.with_tenant(tenant))
@@ -1153,16 +1126,12 @@ class DataManager:
         json_output: bool = False,
     ) -> None:
 
-        alias = None
         if not self.client.collections.exists(collection):
             alias_list = self.client.alias.list_all()
             if collection not in alias_list.keys():
                 raise Exception(
                     f"Class '{collection}' does not exist in Weaviate. Create first using ./create_class.py"
                 )
-            else:
-                alias = collection
-                collection = str(alias_list[collection].collection)
 
         col: Collection = self.client.collections.get(collection)
         try:
@@ -1184,8 +1153,6 @@ class DataManager:
         if not json_output:
             click.echo(f"Preparing to update {limit} objects into class '{col.name}'")
         total_updated = 0
-        # Override collection if alias is provided
-        col = col if alias is None else self.client.collections.get(alias)
         for tenant in tenants:
             if tenant == "None":
                 ret = self.__update_data(
@@ -1315,16 +1282,12 @@ class DataManager:
         json_output: bool = False,
     ) -> None:
 
-        alias = None
         if not self.client.collections.exists(collection):
             alias_list = self.client.alias.list_all()
             if collection not in alias_list.keys():
                 raise Exception(
                     f"Class '{collection}' does not exist in Weaviate. Create first using <create class> command."
                 )
-            else:
-                alias = collection
-                collection = str(alias_list[collection].collection)
 
         col: Collection = self.client.collections.get(collection)
         mt_enabled = col.config.get().multi_tenancy_config.enabled
@@ -1342,8 +1305,6 @@ class DataManager:
         tenants = tenants_list if tenants_list is not None else existing_tenants
 
         total_deleted = 0
-        # Override collection if alias is provided
-        col = col if alias is None else self.client.collections.get(alias)
 
         for tenant in tenants:
             if tenant == "None":
@@ -1455,16 +1416,12 @@ class DataManager:
         json_output: bool = False,
     ) -> None:
 
-        alias = None
         if not self.client.collections.exists(collection):
             alias_list = self.client.alias.list_all()
             if collection not in alias_list.keys():
                 raise Exception(
                     f"Class '{collection}' does not exist in Weaviate. Create first using <create class> command."
                 )
-            else:
-                alias = collection
-                collection = str(alias_list[collection].collection)
 
         col: Collection = self.client.collections.get(collection)
         mt_enabled = col.config.get().multi_tenancy_config.enabled
@@ -1508,8 +1465,6 @@ class DataManager:
             "all": wvc.ConsistencyLevel.ALL,
             "one": wvc.ConsistencyLevel.ONE,
         }
-        # Override collection if alias is provided
-        col = col if alias is None else self.client.collections.get(alias)
 
         for tenant in existing_tenants:
             if tenant == "None":


### PR DESCRIPTION
## Summary

- **All data commands (`create`, `query`, `update`, `delete`) now accept collection aliases** via the `--collection` flag. The CLI checks `collections.exists()` first, then falls back to `alias.list_all()` before raising an error.
- **Simplified alias resolution**: Removed the old `alias` parameter threading that fetched config/properties through `alias.get().collection`. Since `collections.get()` natively resolves aliases, all the branching logic was unnecessary — now we just pass the alias name directly to `collections.get()`.
- **Added `--override-alias` flag to `restore backup`**: Resolves alias conflicts during backup restore. When the backup contains a collection with an alias that differs from the current cluster state (e.g., the backup had alias `Movies` pointing to `Movies_v1`, but the cluster now has `Movies` pointing to `Movies_v2`), the restore would fail without this flag. Passing `--override-alias` tells Weaviate to overwrite the existing alias mapping with the one from the backup.
- **Added unit tests** for alias resolution across all four data operations, plus error cases when neither collection nor alias exists, and a test confirming `alias.list_all` is skipped when the collection exists directly.

## Changes

- `weaviate_cli/managers/data_manager.py`: Removed `alias` parameter from internal methods (`__import_json`, `__ingest_data`), removed all `if alias is None` branching — `collections.get()` handles alias resolution natively. Added alias existence check in `create_data`, `update_data`, `delete_data`, `query_data`.
- `weaviate_cli/commands/restore.py`: Added `--override-alias` flag to the restore backup CLI command.
- `weaviate_cli/managers/backup_manager.py`: Pass `override_alias` through to `client.backup.restore(overwrite_alias=...)`.
- `weaviate_cli/defaults.py`: Added `override_alias: bool = False` to `RestoreBackupDefaults`.
- `test/unittests/test_managers/test_data_manager.py`: Added `TestAliasResolution` class with 9 tests covering alias happy path, not-found errors, and direct-collection optimization.

## Test plan

- [x] Unit tests pass (`make test` — 256 passed)
- [x] Functional testing against local 3-node cluster (v1.36.2):
  - Created `AliasTestMovies` collection + `AliasTestAlias` alias
  - `create data --collection AliasTestAlias` — 10 objects inserted
  - `query data --collection AliasTestAlias` — objects fetched successfully
  - `update data --collection AliasTestAlias` — 5 objects updated
  - `delete data --collection AliasTestAlias` — 5 objects deleted
  - Cleanup verified (alias + collection deleted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)