### PR TITLE
Revert "Bump actions/checkout from 5 to 6 in the github-actions group"

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Run Linter and Formatter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
@@ -31,7 +31,7 @@ jobs:
       matrix:
         version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
     - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.version }}
@@ -69,7 +69,7 @@ jobs:
       matrix:
         version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
     - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.version }}
@@ -98,7 +98,7 @@ jobs:
       matrix:
         version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
     - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
         - name: Checkout
-          uses: actions/checkout@v6
+          uses: actions/checkout@v5
           with:
             fetch-depth: 0
         - name: Set up Python 3.11
@@ -51,7 +51,7 @@ jobs:
     needs: [gh-release]
     steps:
         - name: Checkout
-          uses: actions/checkout@v6
+          uses: actions/checkout@v5
           with:
             fetch-depth: 0
         - name: Set up Python 3.11


### PR DESCRIPTION
Reverts weaviate/weaviate-cli#143

All tests that use weaviate-local-k8s started failing due to this PR due to [this](https://github.com/actions/checkout/issues/2299)