### PR TITLE
Add support for object_ttl in weaviate-cli.

### DIFF
--- a/.claude/skills/operating-weaviate-cli/references/collections.md
+++ b/.claude/skills/operating-weaviate-cli/references/collections.md
@@ -39,6 +39,25 @@ weaviate-cli create collection \
 - `--named_vector` -- Enable named vectors
 - `--named_vector_name` -- Named vector name (default: "default")
 - `--replication_deletion_strategy` -- delete_on_conflict, no_automated_resolution, time_based_resolution
+- `--object_ttl_type` -- TTL event type: create, update, property (default: "create")
+- `--object_ttl_time` -- Time to live in seconds (default: None, TTL disabled when omitted)
+- `--object_ttl_filter_expired` -- Filter expired-but-not-yet-deleted objects from queries
+- `--object_ttl_property_name` -- Date property name for TTL when `object_ttl_type=property` (default: "releaseDate"). **Only valid when `--object_ttl_type=property`**; rejected otherwise.
+
+**Object TTL examples:**
+```bash
+# Delete objects 1 hour after creation
+weaviate-cli create collection --collection Movies --object_ttl_type create --object_ttl_time 3600
+
+# Delete objects 24 hours after last update, filtering expired objects
+weaviate-cli create collection --collection Movies --object_ttl_type update --object_ttl_time 86400 --object_ttl_filter_expired
+
+# Delete objects based on default date property (releaseDate)
+weaviate-cli create collection --collection Movies --object_ttl_type property --object_ttl_time 0
+
+# Delete objects based on a custom date property (e.g. for clusters not using weaviate-cli schema)
+weaviate-cli create collection --collection MyCollection --object_ttl_type property --object_ttl_time 86400 --object_ttl_property_name expiresAt --json
+```
 
 ## Update Collection (mutable fields only)
 ```bash
@@ -49,9 +68,27 @@ weaviate-cli update collection \
   --json
 ```
 
-Mutable fields: `--async_enabled`, `--replication_factor`, `--vector_index`, `--description`, `--training_limit`, `--auto_tenant_creation`, `--auto_tenant_activation`, `--replication_deletion_strategy`
+Mutable fields: `--async_enabled`, `--replication_factor`, `--vector_index`, `--description`, `--training_limit`, `--auto_tenant_creation`, `--auto_tenant_activation`, `--replication_deletion_strategy`, `--object_ttl_type`, `--object_ttl_time`, `--object_ttl_filter_expired`, `--object_ttl_property_name` (only when `object_ttl_type=property`)
 
 **Immutable (cannot change after creation):** multitenant, vectorizer, named_vector, shards
+
+**Object TTL options for update:**
+- `--object_ttl_type` -- TTL event type: create, update, property, **disable** (default: "create")
+- `--object_ttl_time` -- Time to live in seconds (set together with type to enable TTL)
+- `--object_ttl_filter_expired` -- Filter expired-but-not-yet-deleted objects (type: bool)
+- `--object_ttl_property_name` -- Date property name when `object_ttl_type=property` (default: "releaseDate"). **Only valid when `--object_ttl_type=property`**; rejected otherwise.
+
+**Object TTL examples:**
+```bash
+# Enable TTL: delete objects 2 hours after creation
+weaviate-cli update collection --collection Movies --object_ttl_type create --object_ttl_time 7200
+
+# Disable TTL on an existing collection
+weaviate-cli update collection --collection Movies --object_ttl_type disable
+
+# Set TTL by custom date property on an existing collection
+weaviate-cli update collection --collection MyCollection --object_ttl_type property --object_ttl_time 86400 --object_ttl_property_name expiresAt --json
+```
 
 ## Delete Collection
 ```bash

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        version: [ "3.10", "3.11", "3.12", "3.13" ]
     steps:
     - uses: actions/checkout@v5
     - uses: actions/setup-python@v6
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        version: [ "3.10", "3.11", "3.12", "3.13" ]
     steps:
     - uses: actions/checkout@v5
     - uses: actions/setup-python@v6
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        version: [ "3.10", "3.11", "3.12", "3.13" ]
     steps:
     - uses: actions/checkout@v5
     - uses: actions/setup-python@v6

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ classifiers =
 include_package_data = True
 python_requires = >=3.9
 install_requires =
-    weaviate-client>=4.16.7
+    weaviate-client>=4.19.0
     click==8.1.7
     semver>=3.0.2
     numpy>=1.24.0

--- a/test/unittests/test_managers/test_collection_manager.py
+++ b/test/unittests/test_managers/test_collection_manager.py
@@ -1,11 +1,37 @@
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, PropertyMock
 from weaviate.exceptions import WeaviateConnectionError
 from weaviate_cli.managers.collection_manager import CollectionManager
 import weaviate.classes.config as wvc
 
 
-def test_create_collection(mock_client):
+@pytest.fixture
+def mock_wvc_object_ttl():
+    """Mock the ObjectTTL configuration classes."""
+    with (
+        patch.object(wvc.Configure, "ObjectTTL", create=True) as mock_configure_ttl,
+        patch.object(wvc.Reconfigure, "ObjectTTL", create=True) as mock_reconfigure_ttl,
+    ):
+        # Setup Configure.ObjectTTL methods
+        mock_configure_ttl.delete_by_creation_time = MagicMock(return_value=MagicMock())
+        mock_configure_ttl.delete_by_update_time = MagicMock(return_value=MagicMock())
+        mock_configure_ttl.delete_by_date_property = MagicMock(return_value=MagicMock())
+        mock_configure_ttl.disable = MagicMock(return_value=MagicMock())
+
+        # Setup Reconfigure.ObjectTTL methods
+        mock_reconfigure_ttl.delete_by_creation_time = MagicMock(
+            return_value=MagicMock()
+        )
+        mock_reconfigure_ttl.delete_by_update_time = MagicMock(return_value=MagicMock())
+        mock_reconfigure_ttl.delete_by_date_property = MagicMock(
+            return_value=MagicMock()
+        )
+        mock_reconfigure_ttl.disable = MagicMock(return_value=MagicMock())
+
+        yield {"configure": mock_configure_ttl, "reconfigure": mock_reconfigure_ttl}
+
+
+def test_create_collection(mock_client, mock_wvc_object_ttl):
     # Setup the mock chain
     mock_collections = MagicMock()
     mock_client.collections = mock_collections
@@ -38,7 +64,7 @@ def test_create_collection(mock_client):
     assert create_call_kwargs["sharding_config"] is None  # since shards = 1
 
 
-def test_create_existing_collection(mock_client):
+def test_create_existing_collection(mock_client, mock_wvc_object_ttl):
     # Setup
     mock_collections = MagicMock()
     mock_client.collections = mock_collections
@@ -62,7 +88,7 @@ def test_create_existing_collection(mock_client):
     mock_collections.create.assert_not_called()
 
 
-def test_create_collection_failure(mock_client):
+def test_create_collection_failure(mock_client, mock_wvc_object_ttl):
     # Setup
     mock_collections = MagicMock()
     mock_client.collections = mock_collections
@@ -124,7 +150,7 @@ def test_delete_nonexistent_collection(mock_client):
         manager.delete_collection(collection="TestCollection", all=False)
 
 
-def test_update_collection(mock_client):
+def test_update_collection(mock_client, mock_wvc_object_ttl):
 
     mock_collections = MagicMock()
     mock_client.collections = mock_collections
@@ -198,3 +224,556 @@ def test_update_nonexistent_collection(mock_client):
 
     mock_collections.exists.assert_called_once_with("TestCollection")
     mock_collections.update.assert_not_called()
+
+
+def test_create_collection_with_ttl_create_type(mock_client, mock_wvc_object_ttl):
+    """Test creating a collection with object TTL using 'create' type."""
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_collections.exists.side_effect = [False, True]
+
+    manager = CollectionManager(mock_client)
+
+    manager.create_collection(
+        collection="TestCollection",
+        replication_factor=3,
+        vector_index="hnsw",
+        object_ttl_type="create",
+        object_ttl_time=3600,
+        object_ttl_filter_expired=True,
+    )
+
+    mock_collections.create.assert_called_once()
+    create_call_kwargs = mock_collections.create.call_args.kwargs
+    assert create_call_kwargs["name"] == "TestCollection"
+    assert create_call_kwargs["object_ttl_config"] is not None
+    # Verify the correct TTL method was called
+    mock_wvc_object_ttl["configure"].delete_by_creation_time.assert_called_once_with(
+        time_to_live=3600,
+        filter_expired_objects=True,
+    )
+
+
+def test_create_collection_with_ttl_update_type(mock_client, mock_wvc_object_ttl):
+    """Test creating a collection with object TTL using 'update' type."""
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_collections.exists.side_effect = [False, True]
+
+    manager = CollectionManager(mock_client)
+
+    manager.create_collection(
+        collection="TestCollection",
+        replication_factor=3,
+        vector_index="hnsw",
+        object_ttl_type="update",
+        object_ttl_time=7200,
+        object_ttl_filter_expired=False,
+    )
+
+    mock_collections.create.assert_called_once()
+    create_call_kwargs = mock_collections.create.call_args.kwargs
+    assert create_call_kwargs["name"] == "TestCollection"
+    assert create_call_kwargs["object_ttl_config"] is not None
+    # Verify the correct TTL method was called
+    mock_wvc_object_ttl["configure"].delete_by_update_time.assert_called_once_with(
+        time_to_live=7200,
+        filter_expired_objects=False,
+    )
+
+
+def test_create_collection_with_ttl_property_type(mock_client, mock_wvc_object_ttl):
+    """Test creating a collection with object TTL using 'property' type."""
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_collections.exists.side_effect = [False, True]
+
+    manager = CollectionManager(mock_client)
+
+    manager.create_collection(
+        collection="TestCollection",
+        replication_factor=3,
+        vector_index="hnsw",
+        object_ttl_type="property",
+        object_ttl_time=86400,
+        object_ttl_filter_expired=True,
+    )
+
+    mock_collections.create.assert_called_once()
+    create_call_kwargs = mock_collections.create.call_args.kwargs
+    assert create_call_kwargs["name"] == "TestCollection"
+    assert create_call_kwargs["object_ttl_config"] is not None
+    # Verify the correct TTL method was called
+    mock_wvc_object_ttl["configure"].delete_by_date_property.assert_called_once_with(
+        property_name="releaseDate",
+        ttl_offset=86400,
+        filter_expired_objects=True,
+    )
+
+
+def test_create_collection_with_ttl_property_type_custom_property_name(
+    mock_client, mock_wvc_object_ttl
+):
+    """Test creating a collection with object TTL 'property' type and custom property name."""
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_collections.exists.side_effect = [False, True]
+
+    manager = CollectionManager(mock_client)
+
+    manager.create_collection(
+        collection="TestCollection",
+        replication_factor=3,
+        vector_index="hnsw",
+        object_ttl_type="property",
+        object_ttl_time=86400,
+        object_ttl_filter_expired=True,
+        object_ttl_property_name="expiresAt",
+    )
+
+    mock_collections.create.assert_called_once()
+    create_call_kwargs = mock_collections.create.call_args.kwargs
+    assert create_call_kwargs["object_ttl_config"] is not None
+    mock_wvc_object_ttl["configure"].delete_by_date_property.assert_called_once_with(
+        property_name="expiresAt",
+        ttl_offset=86400,
+        filter_expired_objects=True,
+    )
+
+
+def test_create_collection_object_ttl_property_name_guardrail(mock_client):
+    """Test that object_ttl_property_name is rejected when object_ttl_type is not 'property'."""
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_collections.exists.return_value = False
+
+    manager = CollectionManager(mock_client)
+
+    with pytest.raises(Exception) as exc_info:
+        manager.create_collection(
+            collection="TestCollection",
+            replication_factor=3,
+            vector_index="hnsw",
+            object_ttl_type="create",
+            object_ttl_time=3600,
+            object_ttl_property_name="expiresAt",
+        )
+
+    assert (
+        "object_ttl_property_name is only valid when object_ttl_type is 'property'"
+        in str(exc_info.value)
+    )
+    mock_collections.create.assert_not_called()
+
+
+def test_create_collection_with_ttl_property_type_default_property_name(
+    mock_client, mock_wvc_object_ttl
+):
+    """Test that object_ttl_type=property with no property name uses default 'releaseDate'."""
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_collections.exists.side_effect = [False, True]
+
+    manager = CollectionManager(mock_client)
+
+    manager.create_collection(
+        collection="TestCollection",
+        replication_factor=3,
+        vector_index="hnsw",
+        object_ttl_type="property",
+        object_ttl_time=86400,
+        object_ttl_property_name=None,
+    )
+
+    mock_collections.create.assert_called_once()
+    mock_wvc_object_ttl["configure"].delete_by_date_property.assert_called_once_with(
+        property_name="releaseDate",
+        ttl_offset=86400,
+        filter_expired_objects=None,
+    )
+
+
+def test_create_collection_with_ttl_time_zero(mock_client, mock_wvc_object_ttl):
+    """Test creating a collection with TTL time=0 applies TTL config (not treated as unset)."""
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_collections.exists.side_effect = [False, True]
+
+    manager = CollectionManager(mock_client)
+
+    manager.create_collection(
+        collection="TestCollection",
+        replication_factor=3,
+        vector_index="hnsw",
+        object_ttl_type="property",
+        object_ttl_time=0,
+        object_ttl_filter_expired=False,
+    )
+
+    mock_collections.create.assert_called_once()
+    create_call_kwargs = mock_collections.create.call_args.kwargs
+    assert create_call_kwargs["object_ttl_config"] is not None
+    mock_wvc_object_ttl["configure"].delete_by_date_property.assert_called_once_with(
+        property_name="releaseDate",
+        ttl_offset=0,
+        filter_expired_objects=False,
+    )
+
+
+def test_create_collection_without_ttl_time(mock_client, mock_wvc_object_ttl):
+    """Test creating a collection without TTL time results in no TTL config."""
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_collections.exists.side_effect = [False, True]
+
+    manager = CollectionManager(mock_client)
+
+    manager.create_collection(
+        collection="TestCollection",
+        replication_factor=3,
+        vector_index="hnsw",
+        object_ttl_type="create",
+        object_ttl_time=None,
+    )
+
+    mock_collections.create.assert_called_once()
+    create_call_kwargs = mock_collections.create.call_args.kwargs
+    assert create_call_kwargs["object_ttl_config"] is None
+
+
+def test_update_collection_with_ttl_create_type(mock_client, mock_wvc_object_ttl):
+    """Test updating a collection with object TTL using 'create' type."""
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_client.collections.exists.side_effect = [True, True]
+
+    mock_collection = MagicMock()
+    mock_client.collections.get.return_value = mock_collection
+    mock_collection.config.get.return_value = MagicMock(
+        replication_config=MagicMock(factor=3),
+        multi_tenancy_config=MagicMock(
+            enabled=False, auto_tenant_creation=False, auto_tenant_activation=False
+        ),
+    )
+
+    manager = CollectionManager(mock_client)
+
+    manager.update_collection(
+        collection="TestCollection",
+        object_ttl_type="create",
+        object_ttl_time=3600,
+        object_ttl_filter_expired=True,
+    )
+
+    mock_collection.config.update.assert_called_once()
+    update_call_kwargs = mock_collection.config.update.call_args.kwargs
+    assert update_call_kwargs["object_ttl_config"] is not None
+    # Verify the correct TTL method was called
+    mock_wvc_object_ttl["reconfigure"].delete_by_creation_time.assert_called_once_with(
+        time_to_live=3600,
+        filter_expired_objects=True,
+    )
+
+
+def test_update_collection_with_ttl_update_type(mock_client, mock_wvc_object_ttl):
+    """Test updating a collection with object TTL using 'update' type."""
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_client.collections.exists.side_effect = [True, True]
+
+    mock_collection = MagicMock()
+    mock_client.collections.get.return_value = mock_collection
+    mock_collection.config.get.return_value = MagicMock(
+        replication_config=MagicMock(factor=3),
+        multi_tenancy_config=MagicMock(
+            enabled=False, auto_tenant_creation=False, auto_tenant_activation=False
+        ),
+    )
+
+    manager = CollectionManager(mock_client)
+
+    manager.update_collection(
+        collection="TestCollection",
+        object_ttl_type="update",
+        object_ttl_time=7200,
+        object_ttl_filter_expired=False,
+    )
+
+    mock_collection.config.update.assert_called_once()
+    update_call_kwargs = mock_collection.config.update.call_args.kwargs
+    assert update_call_kwargs["object_ttl_config"] is not None
+    # Verify the correct TTL method was called
+    mock_wvc_object_ttl["reconfigure"].delete_by_update_time.assert_called_once_with(
+        time_to_live=7200,
+        filter_expired_objects=False,
+    )
+
+
+def test_update_collection_with_ttl_property_type(mock_client, mock_wvc_object_ttl):
+    """Test updating a collection with object TTL using 'property' type."""
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_client.collections.exists.side_effect = [True, True]
+
+    mock_collection = MagicMock()
+    mock_client.collections.get.return_value = mock_collection
+    mock_collection.config.get.return_value = MagicMock(
+        replication_config=MagicMock(factor=3),
+        multi_tenancy_config=MagicMock(
+            enabled=False, auto_tenant_creation=False, auto_tenant_activation=False
+        ),
+    )
+
+    manager = CollectionManager(mock_client)
+
+    manager.update_collection(
+        collection="TestCollection",
+        object_ttl_type="property",
+        object_ttl_time=86400,
+        object_ttl_filter_expired=True,
+    )
+
+    mock_collection.config.update.assert_called_once()
+    update_call_kwargs = mock_collection.config.update.call_args.kwargs
+    assert update_call_kwargs["object_ttl_config"] is not None
+    # Verify the correct TTL method was called
+    mock_wvc_object_ttl["reconfigure"].delete_by_date_property.assert_called_once_with(
+        property_name="releaseDate",
+        ttl_offset=86400,
+        filter_expired_objects=True,
+    )
+
+
+def test_update_collection_with_ttl_property_type_custom_property_name(
+    mock_client, mock_wvc_object_ttl
+):
+    """Test updating a collection with object TTL 'property' type and custom property name."""
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_client.collections.exists.side_effect = [True, True]
+
+    mock_collection = MagicMock()
+    mock_client.collections.get.return_value = mock_collection
+    mock_collection.config.get.return_value = MagicMock(
+        replication_config=MagicMock(factor=3),
+        multi_tenancy_config=MagicMock(
+            enabled=False, auto_tenant_creation=False, auto_tenant_activation=False
+        ),
+    )
+
+    manager = CollectionManager(mock_client)
+
+    manager.update_collection(
+        collection="TestCollection",
+        object_ttl_type="property",
+        object_ttl_time=86400,
+        object_ttl_filter_expired=True,
+        object_ttl_property_name="expiresAt",
+    )
+
+    mock_collection.config.update.assert_called_once()
+    update_call_kwargs = mock_collection.config.update.call_args.kwargs
+    assert update_call_kwargs["object_ttl_config"] is not None
+    mock_wvc_object_ttl["reconfigure"].delete_by_date_property.assert_called_once_with(
+        property_name="expiresAt",
+        ttl_offset=86400,
+        filter_expired_objects=True,
+    )
+
+
+def test_update_collection_object_ttl_property_name_guardrail(mock_client):
+    """Test that object_ttl_property_name is rejected when object_ttl_type is not 'property'."""
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_client.collections.exists.return_value = True
+
+    mock_collection = MagicMock()
+    mock_client.collections.get.return_value = mock_collection
+    mock_collection.config.get.return_value = MagicMock(
+        replication_config=MagicMock(factor=3),
+        multi_tenancy_config=MagicMock(
+            enabled=False, auto_tenant_creation=False, auto_tenant_activation=False
+        ),
+    )
+
+    manager = CollectionManager(mock_client)
+
+    with pytest.raises(Exception) as exc_info:
+        manager.update_collection(
+            collection="TestCollection",
+            object_ttl_type="create",
+            object_ttl_time=3600,
+            object_ttl_filter_expired=True,
+            object_ttl_property_name="expiresAt",
+        )
+
+    assert (
+        "object_ttl_property_name is only valid when object_ttl_type is 'property'"
+        in str(exc_info.value)
+    )
+    mock_collection.config.update.assert_not_called()
+
+
+def test_update_collection_with_ttl_property_type_default_property_name(
+    mock_client, mock_wvc_object_ttl
+):
+    """Test that object_ttl_type=property with no property name uses default 'releaseDate'."""
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_client.collections.exists.side_effect = [True, True]
+
+    mock_collection = MagicMock()
+    mock_client.collections.get.return_value = mock_collection
+    mock_collection.config.get.return_value = MagicMock(
+        replication_config=MagicMock(factor=3),
+        multi_tenancy_config=MagicMock(
+            enabled=False, auto_tenant_creation=False, auto_tenant_activation=False
+        ),
+    )
+
+    manager = CollectionManager(mock_client)
+
+    manager.update_collection(
+        collection="TestCollection",
+        object_ttl_type="property",
+        object_ttl_time=86400,
+        object_ttl_property_name=None,
+    )
+
+    mock_collection.config.update.assert_called_once()
+    mock_wvc_object_ttl["reconfigure"].delete_by_date_property.assert_called_once_with(
+        property_name="releaseDate",
+        ttl_offset=86400,
+        filter_expired_objects=None,
+    )
+
+
+def test_update_collection_with_ttl_time_zero(mock_client, mock_wvc_object_ttl):
+    """Test updating a collection with TTL time=0 applies TTL config (not treated as unset)."""
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_client.collections.exists.side_effect = [True, True]
+
+    mock_collection = MagicMock()
+    mock_client.collections.get.return_value = mock_collection
+    mock_collection.config.get.return_value = MagicMock(
+        replication_config=MagicMock(factor=3),
+        multi_tenancy_config=MagicMock(
+            enabled=False, auto_tenant_creation=False, auto_tenant_activation=False
+        ),
+    )
+
+    manager = CollectionManager(mock_client)
+
+    manager.update_collection(
+        collection="TestCollection",
+        object_ttl_type="property",
+        object_ttl_time=0,
+        object_ttl_filter_expired=False,
+    )
+
+    mock_collection.config.update.assert_called_once()
+    update_call_kwargs = mock_collection.config.update.call_args.kwargs
+    assert update_call_kwargs["object_ttl_config"] is not None
+    mock_wvc_object_ttl["reconfigure"].delete_by_date_property.assert_called_once_with(
+        property_name="releaseDate",
+        ttl_offset=0,
+        filter_expired_objects=False,
+    )
+
+
+def test_update_collection_without_ttl_time(mock_client, mock_wvc_object_ttl):
+    """Test updating a collection without TTL time results in no TTL config."""
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_client.collections.exists.side_effect = [True, True]
+
+    mock_collection = MagicMock()
+    mock_client.collections.get.return_value = mock_collection
+    mock_collection.config.get.return_value = MagicMock(
+        replication_config=MagicMock(factor=3),
+        multi_tenancy_config=MagicMock(
+            enabled=False, auto_tenant_creation=False, auto_tenant_activation=False
+        ),
+    )
+
+    manager = CollectionManager(mock_client)
+
+    manager.update_collection(
+        collection="TestCollection",
+        description="Updated description",
+        object_ttl_type="create",
+        object_ttl_time=None,
+    )
+
+    mock_collection.config.update.assert_called_once()
+    update_call_kwargs = mock_collection.config.update.call_args.kwargs
+    assert update_call_kwargs["object_ttl_config"] is None
+
+
+def test_update_collection_with_ttl_and_multitenancy(mock_client, mock_wvc_object_ttl):
+    """Test updating a multitenant collection with object TTL."""
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_client.collections.exists.side_effect = [True, True]
+
+    mock_collection = MagicMock()
+    mock_client.collections.get.return_value = mock_collection
+    mock_collection.config.get.return_value = MagicMock(
+        replication_config=MagicMock(factor=3),
+        multi_tenancy_config=MagicMock(
+            enabled=True, auto_tenant_creation=False, auto_tenant_activation=False
+        ),
+    )
+
+    manager = CollectionManager(mock_client)
+
+    manager.update_collection(
+        collection="TestCollection",
+        object_ttl_type="create",
+        object_ttl_time=3600,
+        object_ttl_filter_expired=True,
+        auto_tenant_creation=True,
+        auto_tenant_activation=True,
+    )
+
+    mock_collection.config.update.assert_called_once()
+    update_call_kwargs = mock_collection.config.update.call_args.kwargs
+    assert update_call_kwargs["object_ttl_config"] is not None
+    assert update_call_kwargs["multi_tenancy_config"].autoTenantCreation is True
+    assert update_call_kwargs["multi_tenancy_config"].autoTenantActivation is True
+    # Verify the correct TTL method was called
+    mock_wvc_object_ttl["reconfigure"].delete_by_creation_time.assert_called_once_with(
+        time_to_live=3600,
+        filter_expired_objects=True,
+    )
+
+
+def test_update_collection_with_ttl_disable_type(mock_client, mock_wvc_object_ttl):
+    """Test updating a collection with object TTL using 'disable' type."""
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_client.collections.exists.side_effect = [True, True]
+
+    mock_collection = MagicMock()
+    mock_client.collections.get.return_value = mock_collection
+    mock_collection.config.get.return_value = MagicMock(
+        replication_config=MagicMock(factor=3),
+        multi_tenancy_config=MagicMock(
+            enabled=False, auto_tenant_creation=False, auto_tenant_activation=False
+        ),
+    )
+
+    manager = CollectionManager(mock_client)
+
+    manager.update_collection(
+        collection="TestCollection",
+        object_ttl_type="disable",
+        object_ttl_time=None,
+    )
+
+    mock_collection.config.update.assert_called_once()
+    update_call_kwargs = mock_collection.config.update.call_args.kwargs
+    assert update_call_kwargs["object_ttl_config"] is not None
+    # Verify the disable method was called
+    mock_wvc_object_ttl["reconfigure"].disable.assert_called_once()

--- a/weaviate_cli/commands/create.py
+++ b/weaviate_cli/commands/create.py
@@ -161,6 +161,29 @@ def create() -> None:
 @click.option(
     "--json", "json_output", is_flag=True, default=False, help="Output in JSON format."
 )
+@click.option(
+    "--object_ttl_type",
+    default=CreateCollectionDefaults.object_ttl_type,
+    type=click.Choice(["create", "update", "property"]),
+    help="Object TTL type, check https://docs.weaviate.io/weaviate/manage-collections/time-to-live for reference (default: 'create').",
+)
+@click.option(
+    "--object_ttl_time",
+    default=CreateCollectionDefaults.object_ttl_time,
+    type=int,
+    help="Object TTL time in seconds (default: None).",
+)
+@click.option(
+    "--object_ttl_filter_expired",
+    is_flag=True,
+    help="Filter expired objects (default: False).",
+)
+@click.option(
+    "--object_ttl_property_name",
+    default=CreateCollectionDefaults.object_ttl_property_name,
+    type=str,
+    help="Date property name for TTL when object_ttl_type is 'property' (default: 'releaseDate'). Only valid when --object_ttl_type=property.",
+)
 @click.pass_context
 def create_collection_cli(
     ctx: click.Context,
@@ -181,9 +204,23 @@ def create_collection_cli(
     named_vector: bool,
     named_vector_name: Optional[str],
     json_output: bool,
+    object_ttl_type: str,
+    object_ttl_time: Optional[int],
+    object_ttl_filter_expired: bool,
+    object_ttl_property_name: Optional[str],
 ) -> None:
     """Create a collection in Weaviate."""
 
+    if (
+        object_ttl_type != "property"
+        and object_ttl_property_name
+        != CreateCollectionDefaults.object_ttl_property_name
+    ):
+        click.echo(
+            "Error: object_ttl_property_name is only valid when object_ttl_type is 'property'.",
+            err=True,
+        )
+        sys.exit(1)
     client = None
     try:
         client = get_client_from_context(ctx)
@@ -207,6 +244,10 @@ def create_collection_cli(
             named_vector=named_vector,
             named_vector_name=named_vector_name,
             json_output=json_output,
+            object_ttl_type=object_ttl_type,
+            object_ttl_time=object_ttl_time,
+            object_ttl_filter_expired=object_ttl_filter_expired,
+            object_ttl_property_name=object_ttl_property_name,
         )
     except Exception as e:
         click.echo(f"Error: {e}")

--- a/weaviate_cli/commands/update.py
+++ b/weaviate_cli/commands/update.py
@@ -86,6 +86,30 @@ def update() -> None:
 @click.option(
     "--json", "json_output", is_flag=True, default=False, help="Output in JSON format."
 )
+@click.option(
+    "--object_ttl_type",
+    default=UpdateCollectionDefaults.object_ttl_type,
+    type=click.Choice(["create", "update", "property", "disable"]),
+    help="Object TTL type, check https://docs.weaviate.io/weaviate/manage-collections/time-to-live for reference (default: 'create'). Use 'disable' to disable object TTL for that collection.",
+)
+@click.option(
+    "--object_ttl_time",
+    default=UpdateCollectionDefaults.object_ttl_time,
+    type=int,
+    help="Object TTL time in seconds (default: None).",
+)
+@click.option(
+    "--object_ttl_filter_expired",
+    type=bool,
+    default=UpdateCollectionDefaults.object_ttl_filter_expired,
+    help="Filter expired objects (default: None).",
+)
+@click.option(
+    "--object_ttl_property_name",
+    default=UpdateCollectionDefaults.object_ttl_property_name,
+    type=str,
+    help="Date property name for TTL when object_ttl_type is 'property' (default: 'releaseDate'). Only valid when --object_ttl_type=property.",
+)
 @click.pass_context
 def update_collection_cli(
     ctx: click.Context,
@@ -99,9 +123,23 @@ def update_collection_cli(
     auto_tenant_activation: Optional[bool],
     replication_deletion_strategy: Optional[str],
     json_output: bool,
+    object_ttl_type: str,
+    object_ttl_time: Optional[int],
+    object_ttl_filter_expired: bool,
+    object_ttl_property_name: Optional[str],
 ) -> None:
     """Update a collection in Weaviate."""
 
+    if (
+        object_ttl_type not in ("property", "disable")
+        and object_ttl_property_name
+        != UpdateCollectionDefaults.object_ttl_property_name
+    ):
+        click.echo(
+            "Error: object_ttl_property_name is only valid when object_ttl_type is 'property'.",
+            err=True,
+        )
+        sys.exit(1)
     client = None
     try:
         client = get_client_from_context(ctx)
@@ -118,6 +156,10 @@ def update_collection_cli(
             auto_tenant_activation=auto_tenant_activation,
             replication_deletion_strategy=replication_deletion_strategy,
             json_output=json_output,
+            object_ttl_type=object_ttl_type,
+            object_ttl_time=object_ttl_time,
+            object_ttl_filter_expired=object_ttl_filter_expired,
+            object_ttl_property_name=object_ttl_property_name,
         )
     except Exception as e:
         click.echo(f"Error: {e}")

--- a/weaviate_cli/defaults.py
+++ b/weaviate_cli/defaults.py
@@ -78,6 +78,10 @@ class CreateCollectionDefaults:
     replication_deletion_strategy: str = "no_automated_resolution"
     named_vector: bool = False
     named_vector_name: Optional[str] = "default"
+    object_ttl_type: str = "create"
+    object_ttl_time: Optional[int] = None
+    object_ttl_filter_expired: Optional[bool] = None
+    object_ttl_property_name: str = "releaseDate"
 
 
 @dataclass
@@ -245,6 +249,10 @@ class UpdateCollectionDefaults:
     auto_tenant_creation: Optional[bool] = None
     auto_tenant_activation: Optional[bool] = None
     replication_deletion_strategy: Optional[str] = None
+    object_ttl_type: str = "create"
+    object_ttl_time: Optional[int] = None
+    object_ttl_filter_expired: Optional[bool] = None
+    object_ttl_property_name: str = "releaseDate"
 
 
 @dataclass


### PR DESCRIPTION
Includes three new options when creating or updating a collection: 
-object_ttl_type: The type of even from which measure the time to live 
-object_ttl_time: Time to live for the objects in that collection 
-object_ttl_filter_expired: Filter or not expired, but not yet deleted objects.