### PR TITLE
Add agent skills for operating and contributing to weaviate-cli

### DIFF
--- a/.claude/skills/contributing-to-weaviate-cli/SKILL.md
+++ b/.claude/skills/contributing-to-weaviate-cli/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: contributing-to-weaviate-cli
+description: >-
+  Develops, tests, and reviews weaviate-cli source code. Use this skill when
+  the task involves modifying the weaviate-cli codebase itself. Trigger if
+  the request: asks to add a new command or flag to weaviate-cli; needs to
+  fix a bug in the CLI source code (weaviate_cli/ Python files); involves
+  reviewing a PR that changes weaviate-cli; wants to write or update unit or
+  integration tests for the CLI; asks about the Click-based architecture,
+  command-to-manager pattern, or defaults system; or the working directory is
+  the weaviate-cli repository and Python source files need to be modified.
+  Do NOT use for running weaviate-cli commands against a Weaviate cluster —
+  use operating-weaviate-cli for that.
+---
+
+# Contributing to weaviate-cli
+
+Guide for developing, testing, and maintaining the `weaviate-cli` codebase.
+
+## Development Setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+make install-dev          # pip install -r requirements-dev.txt + pre-commit install
+```
+
+Key development commands:
+```bash
+make format               # Black formatter on cli.py, weaviate_cli/, test/
+make lint                 # Black --check (CI-equivalent)
+make test                 # pytest test/unittests
+make build-all            # python -m build + twine check
+make all                  # format + lint + test + build-all
+```
+
+## Repository Architecture
+
+```
+weaviate-cli/
+  cli.py                        # Entry point: Click group, global options, command registration
+  weaviate_cli/
+    __init__.py                 # Package version
+    defaults.py                 # Dataclass defaults for all commands
+    utils.py                    # Shared helpers: get_client, pp_objects, parse_permission
+    commands/                   # Click command definitions (one file per group)
+      create.py                 # create collection, tenants, data, backup, role, user, alias, replication
+      get.py                    # get collection, tenants, shards, backup, role, user, nodes, alias, replication
+      update.py                 # update collection, tenants, shards, data, user, alias
+      delete.py                 # delete collection, tenants, data, role, user, alias, replication
+      query.py                  # query data, replications, sharding-state
+      restore.py                # restore backup
+      cancel.py                 # cancel backup, replication
+      assign.py                 # assign role, permission
+      revoke.py                 # revoke role, permission
+      benchmark.py              # benchmark qps
+    managers/                   # Business logic (one file per domain)
+      config_manager.py         # ConfigManager: config loading, client creation
+      collection_manager.py     # CollectionManager: CRUD collections
+      tenant_manager.py         # TenantManager: CRUD tenants
+      data_manager.py           # DataManager: ingest/update/delete data
+      backup_manager.py         # BackupManager: backup/restore operations
+      role_manager.py           # RoleManager: RBAC role operations
+      user_manager.py           # UserManager: RBAC user operations
+      node_manager.py           # NodeManager: node information
+      shard_manager.py          # ShardManager: shard operations
+      cluster_manager.py        # ClusterManager: replication operations
+      alias_manager.py          # AliasManager: alias operations
+      benchmark_manager.py      # BenchmarkManager: QPS benchmarks
+    completion/                 # Shell completion helpers
+    datasets/                   # Built-in datasets (Movies)
+    types/                      # Type definitions
+  test/
+    unittests/
+      conftest.py               # Fixtures: mock_client, mock_config, mock_click_context
+      test_cli.py               # CliRunner tests for CLI entry point
+      test_defaults.py          # Defaults dataclass tests
+      test_utils.py             # Utility function tests
+      test_managers/             # Manager unit tests (one per manager)
+    integration/
+      test_integration.py       # Integration tests (requires running cluster)
+      test_auth_integration.py  # RBAC integration tests (requires cluster + RBAC)
+      test_data_integration.py  # Data integration tests
+```
+
+See [references/architecture.md](references/architecture.md) for detailed class hierarchy and patterns.
+
+## Architecture Pattern: Commands -> Managers
+
+Every CLI operation follows this pattern:
+
+1. **`cli.py`**: Top-level Click group registers command groups
+2. **`commands/<group>.py`**: Click decorators define options, validate input, get client from context, call manager
+3. **`managers/<domain>_manager.py`**: Business logic, Weaviate client calls, output formatting
+4. **`defaults.py`**: Dataclass with default values for each command
+
+```
+cli.py (main group)
+  -> commands/create.py (create group)
+    -> @create.command("collection") (Click decorators + options)
+      -> CollectionManager(client).create_collection(...) (business logic)
+        -> defaults.py::CreateCollectionDefaults (default values)
+```
+
+The `ConfigManager` is stored in the Click context (`ctx.obj["config"]`). Commands extract the client via `get_client_from_context(ctx)` from `utils.py`.
+
+## Defaults System
+
+All command defaults live in `weaviate_cli/defaults.py` as dataclasses:
+
+```python
+@dataclass
+class CreateCollectionDefaults:
+    collection: str = "Movies"
+    replication_factor: int = 3
+    vector_index: str = "hnsw"
+    multitenant: bool = False
+    # ... etc
+```
+
+Click options reference these: `default=CreateCollectionDefaults.collection`. This keeps defaults centralized and testable.
+
+When adding a new command, always create a corresponding defaults dataclass.
+
+## Adding a New Command
+
+Step-by-step guide: see [references/adding-commands.md](references/adding-commands.md).
+
+Summary:
+1. Add a defaults dataclass in `defaults.py`
+2. Add Click command in the appropriate `commands/<group>.py`
+3. Add manager method in `managers/<domain>_manager.py`
+4. Add `--json` flag (mandatory for all commands)
+5. Add unit test in `test/unittests/test_managers/`
+6. Update the operating skill documentation
+
+## JSON Output Convention
+
+Every command **must** support `--json`:
+
+**In the Click command:**
+```python
+@click.option("--json", "json_output", is_flag=True, default=False, help="Output in JSON format.")
+```
+
+Note: The parameter is named `json_output` (not `json`) to avoid shadowing Python's `json` module.
+
+**In the manager**, use `print_json_or_text()` from `utils.py`:
+```python
+from weaviate_cli.utils import print_json_or_text
+
+print_json_or_text(
+    data={"collections": collection_list, "total": len(collection_list)},
+    json_output=json_output,
+    text_fn=lambda: click.echo(formatted_text),
+)
+```
+
+**Success JSON shape:**
+```json
+{"status": "success", "message": "..."}
+```
+or structured data with domain-specific fields.
+
+**Error output:** Always `click.echo(f"Error: {e}")` + `sys.exit(1)`.
+
+## Testing
+
+### Unit Tests
+
+Use `CliRunner` for CLI-level tests and `MagicMock` for manager tests:
+
+```python
+# CLI test (test/unittests/test_cli.py)
+from click.testing import CliRunner
+from cli import main
+
+def test_create_collection(cli_runner):
+    result = cli_runner.invoke(main, ["create", "collection", "--json"])
+    assert result.exit_code == 0
+
+# Manager test (test/unittests/test_managers/test_collection_manager.py)
+def test_create_collection(mock_client):
+    mock_client.collections.exists.side_effect = [False, True]
+    manager = CollectionManager(mock_client)
+    manager.create_collection(collection="Test", replication_factor=3)
+    mock_client.collections.create.assert_called_once()
+```
+
+Fixtures in `conftest.py` (shared across all unit tests):
+- `mock_client` -- `MagicMock(spec=weaviate.WeaviateClient)`
+- `mock_config` -- `MagicMock(spec=ConfigManager)`
+- `mock_click_context` -- context with mock config in `ctx.obj`
+
+Note: `cli_runner` is defined locally in `test/unittests/test_cli.py`, not in `conftest.py`.
+
+### Integration Tests
+
+Require a running Weaviate cluster (typically via `weaviate-local-k8s`):
+```bash
+pytest test/integration/test_integration.py
+pytest test/integration/test_auth_integration.py  # Requires RBAC-enabled cluster
+```
+
+See [references/testing.md](references/testing.md) for full patterns.
+
+## CI Pipeline
+
+```
+lint-and-format (Black + build check)
+  -> unit-tests (Python 3.9-3.13, matrix)
+    -> integration-tests (latest Weaviate, weaviate-local-k8s, Python 3.9-3.13)
+    -> integration-auth-tests (RBAC-enabled cluster, Python 3.9-3.13)
+```
+
+- Linting must pass before unit tests run
+- Unit tests must pass before integration tests run
+- Integration tests use `weaviate/weaviate-local-k8s@v2` GitHub Action
+- Auth integration tests create a config with `admin-key` API key
+
+## Code Review Checklist
+
+1. New command has `--json` support
+2. Defaults dataclass added/updated in `defaults.py`
+3. Unit test covers happy path and error cases
+4. Black formatting passes (`make lint`)
+5. No hardcoded paths or credentials
+6. Error messages follow `Error: <description>` pattern
+7. Client is properly closed in `finally` block
+8. Manager method handles both JSON and text output
+
+See [references/code-review.md](references/code-review.md) for detailed checklist.
+
+## Maintaining Skills
+
+When adding new commands or options to `weaviate-cli`, update the agent skills:
+
+1. **Operating skill** (`.claude/skills/operating-weaviate-cli/`):
+   - Add the new command to the **Command Reference** section in `SKILL.md`
+   - Update or create the relevant reference file in `references/`
+   - Update the **Command Groups** table if a new group is added
+   - Update **Workflow Dependencies** if the command introduces new dependencies
+
+2. **Contributing skill** (`.claude/skills/contributing-to-weaviate-cli/`):
+   - Update `references/architecture.md` if new files/modules are added
+   - Update `references/adding-commands.md` if patterns change
+   - Update `references/testing.md` if test infrastructure changes
+
+3. **CLAUDE.md**: Update if development commands or conventions change
+
+## References
+
+- [references/architecture.md](references/architecture.md) -- File-by-file breakdown, class hierarchy, utils helpers
+- [references/adding-commands.md](references/adding-commands.md) -- Complete worked example for new commands
+- [references/testing.md](references/testing.md) -- Test fixtures, patterns, CI details
+- [references/code-review.md](references/code-review.md) -- PR checklist, common pitfalls, conventions

--- a/.claude/skills/contributing-to-weaviate-cli/references/adding-commands.md
+++ b/.claude/skills/contributing-to-weaviate-cli/references/adding-commands.md
@@ -1,0 +1,212 @@
+# Adding Commands Reference
+
+Complete worked example for adding a new command to weaviate-cli.
+
+## Step 1: Add Defaults Dataclass
+
+In `weaviate_cli/defaults.py`, add a dataclass with default values:
+
+```python
+@dataclass
+class CreateWidgetDefaults:
+    collection: str = "Movies"
+    widget_name: str = "default-widget"
+    size: int = 100
+    enabled: bool = False
+```
+
+## Step 2: Add Click Command
+
+In the appropriate `weaviate_cli/commands/<group>.py` file, add the command:
+
+```python
+from weaviate_cli.defaults import CreateWidgetDefaults
+
+@create.command("widget")
+@click.option(
+    "--collection",
+    default=CreateWidgetDefaults.collection,
+    help="The collection to create the widget in.",
+    shell_complete=collection_name_complete,
+)
+@click.option(
+    "--widget_name",
+    default=CreateWidgetDefaults.widget_name,
+    help="Name of the widget.",
+)
+@click.option(
+    "--size",
+    default=CreateWidgetDefaults.size,
+    help=f"Widget size (default: {CreateWidgetDefaults.size}).",
+    type=int,
+)
+@click.option(
+    "--enabled",
+    is_flag=True,
+    help="Enable the widget (default: False).",
+)
+@click.option(
+    "--json", "json_output", is_flag=True, default=False, help="Output in JSON format."
+)
+@click.pass_context
+def create_widget_cli(ctx, collection, widget_name, size, enabled, json_output):
+    """Create a widget in Weaviate."""
+    client = None
+    try:
+        client = get_client_from_context(ctx)
+        manager = WidgetManager(client)
+        manager.create_widget(
+            collection=collection,
+            widget_name=widget_name,
+            size=size,
+            enabled=enabled,
+            json_output=json_output,
+        )
+    except Exception as e:
+        click.echo(f"Error: {e}")
+        if client:
+            client.close()
+        sys.exit(1)
+    finally:
+        if client:
+            client.close()
+```
+
+### Key patterns to follow:
+
+- **Parameter naming:** `--json` is aliased to `json_output` to avoid shadowing Python's `json` module
+- **Default references:** Always use `CreateWidgetDefaults.field_name`, never hardcode defaults
+- **Client lifecycle:** Get client in try, close in finally, echo error and exit(1) in except
+- **Shell completion:** Use `shell_complete=collection_name_complete` for collection options
+- **Boolean flags:** Use `is_flag=True` for boolean options
+- **Choice options:** Use `type=click.Choice([...])` for constrained values
+- **Help text:** Include default value in help string
+
+## Step 3: Add Manager
+
+Create `weaviate_cli/managers/widget_manager.py` (or add to an existing manager):
+
+```python
+import click
+import json
+from weaviate import WeaviateClient
+from weaviate_cli.utils import print_json_or_text
+
+
+class WidgetManager:
+    def __init__(self, client: WeaviateClient):
+        self.client = client
+
+    def create_widget(
+        self,
+        collection: str,
+        widget_name: str,
+        size: int,
+        enabled: bool,
+        json_output: bool = False,
+    ):
+        # Validation
+        if not self.client.collections.exists(collection):
+            raise Exception(f"Collection '{collection}' does not exist.")
+
+        # Business logic
+        result = self.client.collections.get(collection).do_something(
+            name=widget_name, size=size, enabled=enabled
+        )
+
+        # Output
+        data = {
+            "status": "success",
+            "message": f"Widget '{widget_name}' created in collection '{collection}'.",
+            "widget": {"name": widget_name, "size": size, "enabled": enabled},
+        }
+        print_json_or_text(
+            data=data,
+            json_output=json_output,
+            text_fn=lambda: click.echo(
+                f"Widget '{widget_name}' created successfully in '{collection}'."
+            ),
+        )
+```
+
+### Manager patterns:
+
+- Raise exceptions with descriptive messages (caught by command's except block)
+- Use `print_json_or_text()` for dual output support
+- Accept `json_output: bool = False` parameter
+- Don't call `sys.exit()` from managers -- let the command handle it
+
+## Step 4: Add Unit Test
+
+Create `test/unittests/test_managers/test_widget_manager.py`:
+
+```python
+import pytest
+from unittest.mock import MagicMock
+from weaviate_cli.managers.widget_manager import WidgetManager
+
+
+def test_create_widget(mock_client):
+    # Setup mock chain
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_collections.exists.return_value = True
+    mock_collection = MagicMock()
+    mock_collections.get.return_value = mock_collection
+
+    manager = WidgetManager(mock_client)
+    manager.create_widget(
+        collection="TestCollection",
+        widget_name="test-widget",
+        size=50,
+        enabled=True,
+    )
+
+    mock_collections.exists.assert_called_once_with("TestCollection")
+    mock_collections.get.assert_called_once_with("TestCollection")
+
+
+def test_create_widget_collection_not_found(mock_client):
+    mock_client.collections.exists.return_value = False
+    manager = WidgetManager(mock_client)
+
+    with pytest.raises(Exception) as exc_info:
+        manager.create_widget(
+            collection="NonExistent",
+            widget_name="test-widget",
+            size=50,
+        )
+
+    assert "does not exist" in str(exc_info.value)
+```
+
+### Test patterns:
+
+- Use `mock_client` fixture from `conftest.py`
+- Test happy path: verify correct calls were made
+- Test error path: verify exception raised with correct message
+- Mock chains: `mock_client.collections.get.return_value = mock_collection`
+
+## Step 5: Add Import
+
+If you created a new manager, import it in the command file:
+
+```python
+from weaviate_cli.managers.widget_manager import WidgetManager
+```
+
+## Step 6: Update Documentation
+
+1. Add the command to `.claude/skills/operating-weaviate-cli/SKILL.md` command reference
+2. Update or create the relevant reference file in `.claude/skills/operating-weaviate-cli/references/`
+3. Update `CLAUDE.md` if the command introduces new patterns
+
+## Checklist
+
+- [ ] Defaults dataclass in `defaults.py`
+- [ ] Click command with `--json` support
+- [ ] Manager with `print_json_or_text()` output
+- [ ] Unit test (happy path + error path)
+- [ ] Import in command file
+- [ ] Black formatting passes (`make format && make lint`)
+- [ ] Skill documentation updated

--- a/.claude/skills/contributing-to-weaviate-cli/references/architecture.md
+++ b/.claude/skills/contributing-to-weaviate-cli/references/architecture.md
@@ -1,0 +1,146 @@
+# Architecture Reference
+
+Detailed breakdown of the weaviate-cli codebase structure and patterns.
+
+## Entry Point: `cli.py`
+
+The CLI entry point defines the top-level Click group with global options (`--config-file`, `--user`, `--version`) and registers all command groups:
+
+```python
+@click.group()
+@click.option("--config-file", ...)
+@click.option("--user", ...)
+@click.option("--version", is_flag=True, callback=print_version, is_eager=True, ...)
+@click.pass_context
+def main(ctx, config_file, user):
+    try:
+        ctx.obj = {"config": ConfigManager(config_file, user)}
+    except Exception as e:
+        click.echo(f"Fatal Error: {e}")
+        sys.exit(1)
+
+main.add_command(create)
+main.add_command(delete)
+# ... etc
+```
+
+Key points:
+- `ConfigManager` is created once and stored in `ctx.obj["config"]`
+- Config creation is wrapped in try/except -- uses `"Fatal Error:"` prefix (distinct from the `"Error:"` prefix used in commands)
+- Commands extract the client via `get_client_from_context(ctx)` from `utils.py`
+- The `--version` flag uses an eager callback to print and exit
+
+## Command Files: `weaviate_cli/commands/`
+
+Each file defines a Click group and its subcommands. Pattern:
+
+```python
+@click.group()
+def create():
+    """Create resources in Weaviate."""
+    pass
+
+@create.command("collection")
+@click.option("--collection", default=CreateCollectionDefaults.collection, ...)
+@click.option("--json", "json_output", is_flag=True, default=False, ...)
+@click.pass_context
+def create_collection_cli(ctx, collection, ..., json_output):
+    client = None
+    try:
+        client = get_client_from_context(ctx)
+        manager = CollectionManager(client)
+        manager.create_collection(collection=collection, ...)
+    except Exception as e:
+        click.echo(f"Error: {e}")
+        if client:
+            client.close()
+        sys.exit(1)
+    finally:
+        if client:
+            client.close()
+```
+
+Every command follows this structure:
+1. Click decorators with options referencing defaults
+2. `json_output` parameter (aliased from `--json`)
+3. Try/except/finally with client cleanup
+4. Delegate to manager for business logic
+
+## Manager Files: `weaviate_cli/managers/`
+
+Managers encapsulate business logic. Each takes a `WeaviateClient` in `__init__`:
+
+```python
+class CollectionManager:
+    def __init__(self, client: WeaviateClient):
+        self.client = client
+
+    def create_collection(self, collection, replication_factor, ...):
+        if self.client.collections.exists(collection):
+            raise Exception(f"Error: Collection '{collection}' already exists...")
+        self.client.collections.create(name=collection, ...)
+```
+
+Managers handle:
+- Input validation and error messages
+- Weaviate client API calls
+- Output formatting (JSON vs text via `print_json_or_text`)
+
+## ConfigManager: `weaviate_cli/managers/config_manager.py`
+
+Handles configuration loading and client creation:
+
+- Default config path: `~/.config/weaviate/config.json`
+- If no config file exists and none specified, creates default (localhost) config
+- Supports three connection modes: local, Weaviate Cloud, custom host
+- `get_client()` returns sync client, `get_async_client()` returns async client
+- Handles `SLOW_CONNECTION` env var for doubled timeouts
+- For `auth.type == "user"`, requires `--user` flag to select API key
+
+## Defaults: `weaviate_cli/defaults.py`
+
+Centralized defaults as dataclasses. One dataclass per command:
+
+```python
+@dataclass
+class CreateCollectionDefaults:
+    collection: str = "Movies"
+    replication_factor: int = 3
+    vector_index: str = "hnsw"
+    # ...
+```
+
+Also contains:
+- `PERMISSION_HELP_STRING` -- Multi-line help text for `-p` flag
+- `QUERY_MAXIMUM_RESULTS` -- Hard limit for query results
+- `MAX_OBJECTS_PER_BATCH` -- Batch size cap
+- `MAX_WORKERS` -- Computed from CPU count (capped at 32)
+
+## Utils: `weaviate_cli/utils.py`
+
+Shared utility functions:
+
+| Function | Purpose |
+|----------|---------|
+| `get_client_from_context(ctx)` | Extract sync client from Click context |
+| `get_async_client_from_context(ctx)` | Extract async client from Click context |
+| `print_json_or_text(data, json_output, text_fn)` | Output JSON or formatted text |
+| `pp_objects(response, properties, json_output)` | Pretty-print query results |
+| `parse_permission(perm)` | Parse permission string to RBAC objects |
+| `older_than_version(client, version)` | Check if Weaviate server is older than given version |
+| `is_version_older_than(version, check_version)` | Compare two semver strings |
+| `get_random_string(length)` | Random string generator |
+
+## Completion: `weaviate_cli/completion/`
+
+Shell completion helpers for Click options:
+- `collection_name_complete` -- Auto-complete collection names
+- `role_name_complete` -- Auto-complete role names
+
+## Types: `weaviate_cli/types/`
+
+Type definitions used across the codebase.
+
+## Datasets: `weaviate_cli/datasets/`
+
+Built-in datasets (Movies) used for non-randomized data ingestion.

--- a/.claude/skills/contributing-to-weaviate-cli/references/code-review.md
+++ b/.claude/skills/contributing-to-weaviate-cli/references/code-review.md
@@ -1,0 +1,124 @@
+# Code Review Reference
+
+PR checklist, common pitfalls, and conventions for weaviate-cli.
+
+## PR Checklist
+
+### Required for All PRs
+
+- [ ] `make lint` passes (Black formatting)
+- [ ] `make test` passes (unit tests)
+- [ ] No hardcoded paths or credentials
+- [ ] No debug/print statements left in code
+
+### Required for New Commands
+
+- [ ] `--json` flag with `json_output` parameter name
+- [ ] Defaults dataclass in `defaults.py`
+- [ ] Manager method with `print_json_or_text()` for output
+- [ ] Client properly closed in `finally` block
+- [ ] Error messages follow `Error: <description>` pattern
+- [ ] Unit test for happy path
+- [ ] Unit test for error path (e.g., missing collection)
+- [ ] Operating skill documentation updated (SKILL.md + reference file)
+
+### Required for New Options
+
+- [ ] Default value from defaults dataclass (not hardcoded)
+- [ ] Help text includes default value
+- [ ] `type=click.Choice([...])` for constrained values
+- [ ] Parameter passed through command -> manager
+- [ ] Unit test covers the new option
+
+## Common Pitfalls
+
+### 1. Shadowing `json` Module
+
+Wrong:
+```python
+def my_function(json: bool):  # shadows json module
+    import json  # won't work
+```
+
+Right:
+```python
+@click.option("--json", "json_output", is_flag=True, ...)
+def my_function(json_output: bool):
+    import json  # works fine
+```
+
+### 2. Client Not Closed on Error
+
+Wrong:
+```python
+client = get_client_from_context(ctx)
+manager = SomeManager(client)
+manager.do_something()  # if this raises, client leaks
+client.close()
+```
+
+Right:
+```python
+client = None
+try:
+    client = get_client_from_context(ctx)
+    manager = SomeManager(client)
+    manager.do_something()
+except Exception as e:
+    click.echo(f"Error: {e}")
+    if client:
+        client.close()
+    sys.exit(1)
+finally:
+    if client:
+        client.close()
+```
+
+### 3. Hardcoded Defaults
+
+Wrong:
+```python
+@click.option("--collection", default="Movies", ...)
+```
+
+Right:
+```python
+@click.option("--collection", default=CreateCollectionDefaults.collection, ...)
+```
+
+### 4. Missing `sys.exit(1)` on Error
+
+Commands must exit with code 1 on error for proper scripting support. Don't just echo the error.
+
+### 5. Not Passing `json_output` to Manager
+
+Every manager method that produces output should accept and use `json_output`.
+
+## Code Conventions
+
+### Formatting
+
+- **Black** formatter with default settings
+- No custom line length -- Black's default (88 chars)
+- Run `make format` before committing
+
+### Naming
+
+- Command functions: `<action>_<resource>_cli` (e.g., `create_collection_cli`)
+- Manager classes: `<Resource>Manager` (e.g., `CollectionManager`)
+- Manager methods: `<action>_<resource>` (e.g., `create_collection`)
+- Defaults classes: `<Action><Resource>Defaults` (e.g., `CreateCollectionDefaults`)
+- Test functions: `test_<action>_<resource>[_<scenario>]` (e.g., `test_create_existing_collection`)
+
+### Error Messages
+
+- Command level: `click.echo(f"Error: {e}")`
+- Manager level: `raise Exception(f"Description of what went wrong.")`
+- Validation: `click.echo("Error: --flag has no effect unless ..."); sys.exit(1)`
+
+### Git Workflow
+
+- Branch naming: `<username>/<feature-description>`
+- Main branch: `master`
+- PRs require CI passing
+- Pre-commit hooks: `make install-dev` sets up Black

--- a/.claude/skills/contributing-to-weaviate-cli/references/testing.md
+++ b/.claude/skills/contributing-to-weaviate-cli/references/testing.md
@@ -1,0 +1,201 @@
+# Testing Reference
+
+Unit test and integration test patterns for weaviate-cli.
+
+## Running Tests
+
+```bash
+make test                                          # All unit tests
+pytest test/unittests                              # Same as above
+pytest test/unittests/test_managers/test_collection_manager.py  # Single file
+pytest test/unittests -k "test_create_collection"  # Pattern match
+pytest test/integration/test_integration.py        # Integration (needs cluster)
+pytest test/integration/test_auth_integration.py   # RBAC integration (needs cluster + RBAC)
+```
+
+## Fixtures (`test/unittests/conftest.py`)
+
+```python
+@pytest.fixture
+def mock_client():
+    """MagicMock with WeaviateClient spec -- use for manager tests."""
+    return MagicMock(spec=weaviate.WeaviateClient)
+
+@pytest.fixture
+def mock_config():
+    """MagicMock with ConfigManager spec."""
+    return MagicMock(spec=ConfigManager)
+
+@pytest.fixture
+def mock_click_context(mock_config):
+    """Mock Click context with config in ctx.obj."""
+    ctx = MagicMock()
+    ctx.obj = {"config": mock_config}
+    return ctx
+```
+
+## Unit Test Patterns
+
+### Manager Tests
+
+Test managers directly using `mock_client`:
+
+```python
+def test_create_collection(mock_client):
+    # 1. Setup mock chain
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_collections.exists.side_effect = [False, True]  # doesn't exist, then exists after create
+
+    # 2. Create manager and call method
+    manager = CollectionManager(mock_client)
+    manager.create_collection(
+        collection="TestCollection",
+        replication_factor=3,
+        vector_index="hnsw",
+        async_enabled=True,
+    )
+
+    # 3. Assert calls
+    assert mock_collections.exists.call_count == 2
+    mock_collections.create.assert_called_once()
+
+    # 4. Verify parameters
+    create_call_kwargs = mock_collections.create.call_args.kwargs
+    assert create_call_kwargs["name"] == "TestCollection"
+    assert create_call_kwargs["replication_config"].factor == 3
+```
+
+### CLI Tests
+
+Test CLI commands using `CliRunner`. Note: the `cli_runner` fixture is defined locally in `test/unittests/test_cli.py`, not in `conftest.py`.
+
+```python
+# In test/unittests/test_cli.py
+from click.testing import CliRunner
+from cli import main
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+def test_main_help(cli_runner):
+    result = cli_runner.invoke(main, ["--help"])
+    assert result.exit_code == 0
+    assert "Usage:" in result.output
+
+def test_invalid_command(cli_runner):
+    result = cli_runner.invoke(main, ["invalid_command"])
+    assert result.exit_code == 2
+    assert "No such command" in result.output
+```
+
+### Error Path Tests
+
+Always test error conditions:
+
+```python
+def test_create_existing_collection(mock_client):
+    mock_client.collections.exists.return_value = True
+    manager = CollectionManager(mock_client)
+
+    with pytest.raises(Exception) as exc_info:
+        manager.create_collection(collection="TestCollection")
+
+    assert "already exists" in str(exc_info.value)
+    mock_client.collections.create.assert_not_called()
+```
+
+### Mock Chain Patterns
+
+Common mock chains for the Weaviate client:
+
+```python
+# Collections
+mock_client.collections.exists.return_value = True
+mock_client.collections.create.return_value = MagicMock()
+mock_client.collections.get.return_value = mock_collection
+mock_client.collections.list_all.return_value = {"Movies": mock_config}
+mock_client.collections.delete.return_value = None
+
+# Tenants
+mock_collection = MagicMock()
+mock_client.collections.get.return_value = mock_collection
+mock_collection.tenants.get.return_value = {"Tenant-0": mock_tenant}
+mock_collection.tenants.create.return_value = None
+
+# Nodes
+mock_client.cluster.nodes.return_value = [mock_node]
+
+# Backups
+mock_client.backup.create.return_value = mock_backup_response
+```
+
+## Test Coverage
+
+Managers with unit tests in `test/unittests/test_managers/`:
+- `AliasManager` — create, update, delete, get, print (json + text)
+- `BackupManager` — create, restore, get, cancel (json + text, error cases)
+- `ClusterManager` — replication CRUD, print_replication/print_replications (json + text)
+- `CollectionManager` — create, update, delete, get
+- `ConfigManager` — config loading, client creation
+- `DataManager` — create, update, delete (basic happy path)
+- `NodeManager` — get nodes (json + text)
+- `RoleManager` — create, delete, add_permission, revoke_permission (json + text)
+- `ShardManager` — get, update shards
+- `TenantManager` — create, delete, get, update tenants (json + text, version branching)
+- `UserManager` — create, update, delete, add_role, revoke_role, print helpers
+
+Manager **without** unit tests:
+- `BenchmarkManager` — async + complex output; covered by integration tests
+
+## Integration Tests
+
+### Requirements
+
+- Running Weaviate cluster (typically via `weaviate-local-k8s`)
+- For `test_auth_integration.py`: RBAC-enabled cluster with config at `~/.config/weaviate/config.json`
+
+### CI Setup
+
+Integration tests in CI use the `weaviate/weaviate-local-k8s@v2` GitHub Action:
+
+```yaml
+- uses: weaviate/weaviate-local-k8s@v2
+  with:
+    workers: 1
+    replicas: 1
+    weaviate-version: ${{ env.WEAVIATE_VERSION }}
+    modules: "text2vec-transformers-model2vec,text2vec-contextionary"
+    enable-backup: true
+    dynamic-users: true      # For user management tests
+    rbac: true               # For auth integration tests
+```
+
+### Local Integration Testing
+
+To run integration tests locally:
+
+```bash
+# Start a local cluster (e.g., using weaviate-local-k8s or docker-compose)
+# Then run:
+pytest test/integration/test_integration.py
+```
+
+For auth tests, create a config first:
+```bash
+mkdir -p ~/.config/weaviate
+echo '{"host":"localhost","http_port":"8080","grpc_port":"50051","auth":{"type":"api_key","api_key":"admin-key"}}' > ~/.config/weaviate/config.json
+pytest test/integration/test_auth_integration.py
+```
+
+## CI Pipeline Details
+
+The CI runs in GitHub Actions (`.github/workflows/main.yaml`):
+
+1. **lint-and-format**: Black check + build/twine check (Python 3.11)
+2. **unit-tests** (needs lint): Matrix across Python 3.9-3.13, generates HTML reports
+3. **integration-tests** (needs unit): Latest Weaviate version, modules enabled, backup enabled
+4. **integration-auth-tests** (needs unit): Same as integration but with RBAC enabled
+
+All test jobs upload HTML test reports as artifacts.

--- a/.claude/skills/operating-weaviate-cli/SKILL.md
+++ b/.claude/skills/operating-weaviate-cli/SKILL.md
@@ -1,0 +1,384 @@
+---
+name: operating-weaviate-cli
+description: >-
+  Operates Weaviate vector databases through the weaviate-cli tool. Use this
+  skill whenever "weaviate-cli" appears in the prompt, or when the user wants
+  to interact with a running Weaviate cluster. Trigger if the request:
+  mentions weaviate-cli explicitly; asks to create, query, update, or delete
+  collections, tenants, or data in Weaviate; needs to manage RBAC roles and
+  users; wants to run, restore, or cancel backups; asks about cluster health,
+  node status, or shards; needs to manage replication or aliases; wants to
+  benchmark a Weaviate cluster; or is testing/verifying Weaviate functionality
+  from the command line (even if the primary task is testing code changes).
+  Do NOT use for developing or modifying the weaviate-cli source code — use
+  contributing-to-weaviate-cli for that.
+---
+
+# Operating weaviate-cli
+
+Manage Weaviate vector databases through the `weaviate-cli` command-line tool.
+
+## Prerequisites
+
+Install the CLI:
+```bash
+pip install weaviate-cli
+# or
+brew install weaviate/tap/weaviate-cli
+```
+
+Verify connectivity:
+```bash
+weaviate-cli get nodes --minimal --json
+```
+
+## Configuration
+
+The CLI reads configuration from `~/.config/weaviate/config.json` by default. Use `--config-file <path>` to override.
+
+**Local development (no config needed):** The CLI defaults to `localhost:8080` (HTTP) and `localhost:50051` (gRPC). No config file is required for local clusters.
+
+**When authentication is needed**, create a config file under `~/.config/weaviate/` with a descriptive filename:
+
+```bash
+# API key auth
+cat > ~/.config/weaviate/cloud-staging.json << 'EOF'
+{
+    "host": "https://your-cluster.weaviate.cloud",
+    "auth": {
+        "type": "api_key",
+        "api_key": "your-api-key"
+    }
+}
+EOF
+weaviate-cli --config-file ~/.config/weaviate/cloud-staging.json get nodes --minimal --json
+```
+
+```bash
+# RBAC / per-user auth (requires --user flag on every command)
+cat > ~/.config/weaviate/local-rbac.json << 'EOF'
+{
+    "host": "localhost",
+    "http_port": "8080",
+    "grpc_port": "50051",
+    "auth": {
+        "type": "user",
+        "admin-user": "admin-key",
+        "readonly-user": "readonly-key"
+    }
+}
+EOF
+weaviate-cli --config-file ~/.config/weaviate/local-rbac.json --user admin-user get nodes --minimal --json
+```
+
+```bash
+# Custom host with separate gRPC endpoint
+cat > ~/.config/weaviate/custom-host.json << 'EOF'
+{
+    "host": "https://custom-host.example.com",
+    "grpc_host": "https://custom-grpc.example.com",
+    "http_port": 443,
+    "grpc_port": 443,
+    "auth": {
+        "type": "api_key",
+        "api_key": "your-api-key"
+    }
+}
+EOF
+```
+
+### Config management rules
+
+- **Never overwrite** `~/.config/weaviate/config.json` without explicit user consent.
+- When creating configs for the agent, use descriptive filenames (e.g., `local-rbac.json`, `cloud-prod.json`).
+- If the user's prompt specifies a config file, use it. Otherwise, assume local defaults (no `--config-file`).
+- Always verify connectivity after creating or switching configs: `weaviate-cli [--config-file ...] get nodes --minimal --json`
+
+## Command Syntax
+
+```
+weaviate-cli [--config-file FILE] [--user USER] <group> <command> [--json] [options]
+```
+
+### Global Options
+
+| Option | Description |
+|--------|-------------|
+| `--config-file <path>` | Path to config JSON file (overrides default) |
+| `--user <name>` | User for RBAC-enabled clusters (required when auth type is `user`) |
+| `--version` | Print CLI version |
+| `--json` | Output in JSON format (use on every command for agent-friendly output) |
+
+### Command Groups
+
+| Group | Description |
+|-------|-------------|
+| `create` | Create collections, tenants, data, backups, roles, users, aliases, replications |
+| `get` | Inspect collections, tenants, shards, backups, roles, users, nodes, aliases, replications |
+| `update` | Update collections, tenants, shards, data, users, aliases |
+| `delete` | Delete collections, tenants, data, roles, users, aliases, replications |
+| `query` | Query data (fetch/vector/keyword/hybrid/uuid), replications, sharding state |
+| `restore` | Restore backups |
+| `cancel` | Cancel backups and replications |
+| `assign` | Assign roles to users, permissions to roles |
+| `revoke` | Revoke roles from users, permissions from roles |
+| `benchmark` | Run QPS benchmarks |
+
+## Command Reference
+
+**Always use `--json` for programmatic consumption.**
+
+### Collections
+
+```bash
+weaviate-cli create collection --collection MyCollection --replication_factor 3 --vector_index hnsw --vectorizer none --json
+weaviate-cli get collection --json                          # List all
+weaviate-cli get collection --collection MyCollection --json # Specific
+weaviate-cli update collection --collection MyCollection --description "Updated" --replication_factor 5 --json
+weaviate-cli delete collection --collection MyCollection --json
+weaviate-cli delete collection --all --json
+```
+
+Key create options: `--multitenant`, `--auto_tenant_creation`, `--auto_tenant_activation`, `--shards N`, `--vectorizer <type>`, `--named_vector`, `--replication_deletion_strategy`
+
+Mutable fields: `--async_enabled`, `--replication_factor`, `--vector_index`, `--description`, `--training_limit`, `--auto_tenant_creation`, `--auto_tenant_activation`, `--replication_deletion_strategy`
+
+See [references/collections.md](references/collections.md) for full options.
+
+### Data
+
+```bash
+weaviate-cli create data --collection Movies --limit 1000 --randomize --json
+weaviate-cli query data --collection Movies --search_type hybrid --query "Action movie" --limit 10 --json
+weaviate-cli update data --collection Movies --limit 100 --randomize --json
+weaviate-cli delete data --collection Movies --limit 100 --json
+weaviate-cli delete data --collection Movies --uuid "abc-123" --json
+```
+
+Search types: `fetch`, `vector` (near_text), `keyword` (bm25), `hybrid`, `uuid`
+
+Key data options: `--consistency_level`, `--auto_tenants N`, `--tenants "T1,T2"`, `--vector_dimensions`, `--batch_size`, `--concurrent_requests`, `--wait_for_indexing`, `--dynamic_batch`, `--multi_vector`
+
+Key query options: `--properties "title,keywords"`, `--tenants "T1"`, `--target_vector "default"`, `--consistency_level`
+
+See [references/data.md](references/data.md) and [references/search.md](references/search.md).
+
+### Tenants
+
+```bash
+weaviate-cli create tenants --collection Movies --number_tenants 100 --tenant_suffix "Tenant" --state active --json
+weaviate-cli get tenants --collection Movies --json
+weaviate-cli get tenants --collection Movies --tenant_id "Tenant-1" --verbose --json
+weaviate-cli update tenants --collection Movies --state cold --number_tenants 100 --json
+weaviate-cli update tenants --collection Movies --state hot --tenants "Tenant-1,Tenant-2" --json
+weaviate-cli delete tenants --collection Movies --number_tenants 100 --json
+weaviate-cli delete tenants --collection Movies --tenants "Tenant-1,Tenant-2" --json
+```
+
+States: `hot`/`active`, `cold`/`inactive`, `frozen`/`offloaded`
+
+See [references/tenants.md](references/tenants.md).
+
+### Backups
+
+```bash
+weaviate-cli create backup --backend s3 --backup_id my-backup --wait --json
+weaviate-cli create backup --backend s3 --backup_id my-backup --include "Movies,Books" --wait --json
+weaviate-cli get backup --backend s3 --backup_id my-backup --json
+weaviate-cli get backup --backend s3 --backup_id my-backup --restore --json
+weaviate-cli restore backup --backend s3 --backup_id my-backup --wait --json
+weaviate-cli cancel backup --backend s3 --backup_id my-backup --json
+```
+
+Backends: `s3`, `gcs`, `filesystem`. Options: `--include`, `--exclude`, `--wait`, `--cpu_for_backup N`
+
+See [references/backups.md](references/backups.md).
+
+### RBAC (Roles, Users, Permissions)
+
+```bash
+weaviate-cli create role --role_name MoviesAdmin -p crud_collections:Movies -p crud_data:Movies --json
+weaviate-cli create user --user_name test-user --json
+weaviate-cli create user --user_name test-user --store --json  # Store API key in config
+weaviate-cli assign role --role_name MoviesAdmin --user_name test-user --json
+weaviate-cli assign role --role_name MoviesAdmin --role_name TenantAdmin --user_name test-user --json  # Multiple roles
+weaviate-cli assign permission -p read_data:Movies --role_name MoviesAdmin --json
+weaviate-cli get role --all --json
+weaviate-cli get role --role_name MoviesAdmin --json
+weaviate-cli get role --user_name test-user --json
+weaviate-cli get user --all --json
+weaviate-cli get user --user_name test-user --json
+weaviate-cli get user --role_name MoviesAdmin --json
+weaviate-cli update user --user_name test-user --rotate_api_key --json
+weaviate-cli update user --user_name test-user --activate --json
+weaviate-cli update user --user_name test-user --deactivate --json
+weaviate-cli revoke role --role_name MoviesAdmin --user_name test-user --json
+weaviate-cli revoke role --role_name MoviesAdmin --user_name oidc-user --user_type oidc --json  # OIDC user
+weaviate-cli revoke permission -p read_data:Movies --role_name MoviesAdmin --json
+weaviate-cli delete role --role_name MoviesAdmin --json
+weaviate-cli delete user --user_name test-user --json
+```
+
+Permission format: `action:target`. See [references/rbac.md](references/rbac.md) for full permission reference.
+
+### Cluster & Nodes
+
+```bash
+weaviate-cli get nodes --json                          # Default view
+weaviate-cli get nodes --minimal --json                # Minimal (fast for large clusters)
+weaviate-cli get nodes --shards --json                 # Per-shard details
+weaviate-cli get nodes --collections --json            # Per-collection details
+weaviate-cli get nodes --collection Movies --json      # Specific collection
+weaviate-cli get shards --json                         # All collections
+weaviate-cli get shards --collection Movies --json     # Specific collection
+weaviate-cli update shards --collection Movies --status READY --json
+weaviate-cli update shards --all --status READY --json
+weaviate-cli query sharding-state Movies --json
+```
+
+### Replication
+
+```bash
+weaviate-cli create replication --collection Movies --shard shard-1 --source-node node-1 --target-node node-2 --type COPY --json
+weaviate-cli get replication <UUID> --json
+weaviate-cli get replication <UUID> --history --json
+weaviate-cli get all-replications --json
+weaviate-cli query replications --collection Movies --json
+weaviate-cli query replications --collection Movies --shard shard-1 --json
+weaviate-cli query replications --target-node node-2 --json
+weaviate-cli query replications --collection Movies --history --json  # Include history
+weaviate-cli cancel replication <UUID> --json
+weaviate-cli delete replication <UUID> --json
+weaviate-cli delete all-replications --json
+```
+
+Types: `COPY` (duplicate shard), `MOVE` (migrate shard)
+
+See [references/cluster.md](references/cluster.md).
+
+### Aliases
+
+```bash
+weaviate-cli create alias MyAlias Movies --json
+weaviate-cli get alias --alias_name MyAlias --json
+weaviate-cli get alias --collection Movies --json
+weaviate-cli get alias --all --json
+weaviate-cli update alias MyAlias Movies_v2 --json
+weaviate-cli delete alias MyAlias --json
+```
+
+### Benchmark
+
+```bash
+weaviate-cli benchmark qps --collection Movies --query-type hybrid --max-duration 300 --json
+weaviate-cli benchmark qps --collection Movies --qps 100 --json              # Fixed QPS
+weaviate-cli benchmark qps --collection Movies --tenant "Tenant-0" --json    # Multi-tenant
+weaviate-cli benchmark qps --collection Movies --output csv --generate-graph --file-alias staging --json
+```
+
+Key options: `--query-type` (hybrid/bm25/near_text), `--qps N`, `--max-duration`, `--test-duration`, `--warmup-duration`, `--limit`, `--consistency-level`, `--latency-threshold`, `--concurrency`, `--query-terms`
+
+See [references/benchmark.md](references/benchmark.md).
+
+## Workflow Dependencies
+
+### Collection Lifecycle
+1. `create collection` -- must exist before any operations on it
+2. `create tenants` -- only if collection has `--multitenant` (or use `--auto_tenant_creation`)
+3. `create data` -- collection must exist; for MT collections, tenants must exist or auto-creation enabled
+4. `query data` -- collection must have data
+5. `delete data` -> `delete tenants` -> `delete collection` (reverse order)
+
+### Multi-Tenancy State Machine
+```
+hot/active  <-->  cold/inactive
+    ^   \              ^
+    |    \             |
+    v     v            v
+      frozen/offloaded
+```
+- `hot`/`active`: data in memory, queryable, accepts writes
+- `cold`/`inactive`: data on disk, not queryable
+- `frozen`/`offloaded`: data in cloud storage, not queryable
+- Tenants can be offloaded directly from `hot`/`active` or from `cold`/`inactive`
+- Data operations require tenants in `hot`/`active` state
+
+### RBAC Workflow
+1. `create role --role_name X -p <permission>` -- create role with permissions
+2. `create user --user_name Y` -- create user (returns API key)
+3. `assign role --role_name X --user_name Y` -- assign role to user
+4. Verify: `get role --role_name X` and `get user --user_name Y`
+5. Cleanup: `revoke role` -> `delete role` / `delete user`
+
+### Backup Workflow
+1. `create backup --backend s3 --backup_id my-backup --wait` -- wait for completion
+2. `get backup --backend s3 --backup_id my-backup` -- check status
+3. `restore backup --backend s3 --backup_id my-backup --wait` -- restore
+4. `cancel backup` -- cancel in-progress backup
+
+### Replication Workflow
+1. `get nodes` -- identify source and target nodes
+2. `get shards --collection X` -- identify shard to replicate
+3. `create replication --collection X --shard S --source-node A --target-node B --type COPY`
+4. `get replication <UUID>` -- monitor progress
+5. `cancel replication <UUID>` -- cancel if needed
+6. `delete replication <UUID>` -- cleanup completed operation
+
+### Alias Workflow
+1. `create collection --collection Movies_v1` -- create the target collection
+2. `create alias Movies Movies_v1` -- create alias pointing to collection
+3. `update alias Movies Movies_v2` -- repoint alias to new collection
+4. `get alias --alias_name Movies` -- inspect alias
+5. `delete alias Movies` -- remove alias
+
+## JSON Output
+
+All commands support `--json` for machine-readable output. Always use `--json` when invoking commands programmatically.
+
+**Success responses** return structured data or:
+```json
+{"status": "success", "message": "..."}
+```
+
+**Error responses** are printed to stderr and the process exits with code 1:
+```
+Error: <description>
+```
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `Config file does not exist` | Missing config | Create config or use `--config-file` |
+| `User must be specified when auth type is 'user'` | Missing `--user` flag | Add `--user <name>` |
+| `User 'X' not found in config file` | User not in config auth section | Add user to config or check spelling |
+| `GRPC connection seems to be unavailable` | gRPC port blocked | Check firewall/network; CLI retries skipping checks |
+| `Error: Collection 'X' does not exist` | Collection not created yet | Run `create collection` first |
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `SLOW_CONNECTION` | Set to `1`/`true` to double all client timeouts |
+| `HOME` | Used to locate default config at `~/.config/weaviate/config.json` |
+
+## Maintaining This Skill
+
+When new commands or options are added to `weaviate-cli`:
+1. Update the **Command Reference** section above with the new command syntax
+2. Update or create the relevant reference file in `references/`
+3. If a new command group is added, update the **Command Groups** table
+4. Ensure all examples include `--json`
+5. Update workflow dependency sections if the new command introduces dependencies
+
+## References
+
+- [references/collections.md](references/collections.md) -- Full collection options and notes
+- [references/data.md](references/data.md) -- Data ingestion options and notes
+- [references/search.md](references/search.md) -- Search types, options, and selection guide
+- [references/tenants.md](references/tenants.md) -- Tenant state machine and management
+- [references/backups.md](references/backups.md) -- Backup/restore options and notes
+- [references/rbac.md](references/rbac.md) -- Permission format, actions, and examples
+- [references/cluster.md](references/cluster.md) -- Nodes, shards, replication operations
+- [references/benchmark.md](references/benchmark.md) -- Benchmark options and output modes
+- [references/config-management.md](references/config-management.md) -- Config patterns and decision tree

--- a/.claude/skills/operating-weaviate-cli/references/backups.md
+++ b/.claude/skills/operating-weaviate-cli/references/backups.md
@@ -1,0 +1,59 @@
+# Backups Reference
+
+Create, inspect, restore, and cancel Weaviate backups.
+
+## Create Backup
+```bash
+weaviate-cli create backup --backend s3 --backup_id my-backup --wait --json
+weaviate-cli create backup --backend s3 --backup_id my-backup --include "Movies,Books" --wait --json
+weaviate-cli create backup --backend gcs --backup_id my-backup --exclude "TempData" --cpu_for_backup 60 --json
+```
+
+## Check Backup Status
+```bash
+weaviate-cli get backup --backend s3 --backup_id my-backup --json
+```
+
+## Check Restore Status
+```bash
+weaviate-cli get backup --backend s3 --backup_id my-backup --restore --json
+```
+
+## Restore Backup
+```bash
+weaviate-cli restore backup --backend s3 --backup_id my-backup --wait --json
+weaviate-cli restore backup --backend s3 --backup_id my-backup --include "Movies" --wait --json
+```
+
+## Cancel Backup
+```bash
+weaviate-cli cancel backup --backend s3 --backup_id my-backup --json
+```
+
+## Options
+
+**Create:**
+- `--backend` -- s3, gcs, filesystem (default: s3)
+- `--backup_id` -- Backup identifier (default: "test-backup")
+- `--include` -- Comma-separated collections to include
+- `--exclude` -- Comma-separated collections to exclude
+- `--wait` -- Wait for completion
+- `--cpu_for_backup` -- CPU percentage for backup (default: 40)
+
+**Restore:**
+- `--backend`, `--backup_id` -- Same as create
+- `--include`, `--exclude` -- Filter which collections to restore
+- `--wait` -- Wait for completion
+
+## Prerequisites
+
+1. Backup backend must be configured on the Weaviate cluster
+2. Collections in `--include`/`--exclude` must exist
+3. For restore: backup must exist and target collections must not already exist (unless overwriting)
+
+## Notes
+
+- `--wait` blocks until the operation completes -- recommended for scripted workflows
+- Without `--wait`, the command returns immediately and you must poll with `get backup`
+- `--cpu_for_backup` controls backup speed vs. resource consumption tradeoff
+- `--include` and `--exclude` are mutually exclusive

--- a/.claude/skills/operating-weaviate-cli/references/benchmark.md
+++ b/.claude/skills/operating-weaviate-cli/references/benchmark.md
@@ -1,0 +1,86 @@
+# Benchmark Reference
+
+Run QPS (Queries Per Second) benchmarks against Weaviate collections.
+
+## Basic Benchmark
+```bash
+weaviate-cli benchmark qps --collection Movies --json
+```
+
+## Custom Benchmark
+```bash
+weaviate-cli benchmark qps \
+  --collection Movies \
+  --query-type hybrid \
+  --max-duration 300 \
+  --test-duration 10 \
+  --warmup-duration 5 \
+  --limit 10 \
+  --consistency-level QUORUM \
+  --json
+```
+
+## Fixed QPS Test
+```bash
+weaviate-cli benchmark qps --collection Movies --qps 100 --json
+```
+
+## Multi-Tenant Benchmark
+```bash
+weaviate-cli benchmark qps --collection Movies --tenant "Tenant-0" --json
+```
+
+## CSV Output with Graph
+```bash
+weaviate-cli benchmark qps \
+  --collection Movies \
+  --output csv \
+  --generate-graph \
+  --file-alias staging \
+  --json
+```
+
+## Custom Query Terms
+```bash
+weaviate-cli benchmark qps \
+  --collection Movies \
+  --query-terms "science fiction" \
+  --query-terms "romantic comedy" \
+  --json
+```
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--collection` | Movies | Collection to benchmark |
+| `--query-type` | hybrid | Search type: hybrid, bm25, near_text |
+| `--max-duration` | 300 | Maximum total test duration (seconds) |
+| `--test-duration` | 10 | Duration of each test phase (seconds) |
+| `--warmup-duration` | 5 | Warmup phase duration (seconds) |
+| `--limit` | 10 | Results per query |
+| `--consistency-level` | QUORUM | ONE, QUORUM, ALL |
+| `--qps` | auto | Fixed QPS (auto-increments if not set) |
+| `--concurrency` | auto | Concurrency level |
+| `--latency-threshold` | 10000 | Max latency in ms before stopping |
+| `--certainty` | false | Compute certainty percentiles |
+| `--fail-on-timeout` | false | Fail if any request exceeds 10s timeout |
+| `--output` | stdout | Output format: stdout, csv |
+| `--generate-graph` | false | Generate graph (requires --output=csv) |
+| `--file-alias` | none | Identifier for output filenames |
+| `--tenant` | none | Tenant for multi-tenant benchmarks |
+| `--query-terms` | default | Custom query terms (repeatable) |
+
+## Prerequisites
+
+1. Collection must exist with data
+2. For `near_text` query type: collection must have a vectorizer
+3. For `--tenant`: collection must be multi-tenant with the specified tenant in `hot`/`active` state
+4. For `--generate-graph`: requires `--output=csv`
+
+## Notes
+
+- Without `--qps`, the benchmark auto-increments QPS until the latency threshold is hit or max duration is reached
+- With `--qps N`, runs at a fixed rate for the specified duration
+- The benchmark uses async operations for high throughput
+- CSV output includes detailed per-phase metrics

--- a/.claude/skills/operating-weaviate-cli/references/cluster.md
+++ b/.claude/skills/operating-weaviate-cli/references/cluster.md
@@ -1,0 +1,91 @@
+# Cluster Operations Reference
+
+Inspect cluster health, node status, shard state, and manage replication operations.
+
+## Node Information
+```bash
+weaviate-cli get nodes --json                          # Default view
+weaviate-cli get nodes --minimal --json                # Minimal (fast, good for large clusters)
+weaviate-cli get nodes --shards --json                 # Per-shard breakdown
+weaviate-cli get nodes --collections --json            # Per-collection breakdown
+weaviate-cli get nodes --collection Movies --json      # Specific collection
+```
+Only one of `--minimal`, `--shards`, `--collections`, `--collection` can be used at a time.
+
+## Shard Information
+```bash
+weaviate-cli get shards --json                         # All collections
+weaviate-cli get shards --collection Movies --json     # Specific collection
+```
+
+## Update Shard Status
+```bash
+weaviate-cli update shards --collection Movies --status READY --json
+weaviate-cli update shards --collection Movies --status READONLY --shards "shard1,shard2" --json
+weaviate-cli update shards --all --status READY --json
+```
+Statuses: `READY`, `READONLY`
+
+## Sharding State
+```bash
+weaviate-cli query sharding-state Movies --json
+weaviate-cli query sharding-state Movies --shard shard-1 --json
+```
+Shows which nodes hold replicas of each shard.
+
+## Replication Operations
+
+**Create (COPY or MOVE a shard):**
+```bash
+weaviate-cli create replication \
+  --collection Movies \
+  --shard shard-1 \
+  --source-node node-1 \
+  --target-node node-2 \
+  --type COPY \
+  --json
+```
+Types: `COPY` (duplicate shard to target), `MOVE` (migrate shard to target, remove from source)
+
+**Inspect:**
+```bash
+weaviate-cli get replication <UUID> --json
+weaviate-cli get replication <UUID> --history --json
+weaviate-cli get all-replications --json
+```
+
+**Query replications with filters:**
+```bash
+weaviate-cli query replications --json                                    # All
+weaviate-cli query replications --collection Movies --json                # By collection
+weaviate-cli query replications --collection Movies --shard shard-1 --json  # By shard
+weaviate-cli query replications --target-node node-2 --json               # By target node
+weaviate-cli query replications --history --json                          # Include history
+```
+
+**Cancel/Delete:**
+```bash
+weaviate-cli cancel replication <UUID> --json
+weaviate-cli delete replication <UUID> --json
+weaviate-cli delete all-replications --json
+```
+
+## Replication Workflow
+
+1. Identify nodes: `get nodes --minimal --json`
+2. Identify shards: `get shards --collection X --json` or `query sharding-state X --json`
+3. Start replication: `create replication --collection X --shard S --source-node A --target-node B --type COPY --json`
+4. Monitor: `get replication <UUID> --json`
+5. Cleanup: `delete replication <UUID> --json`
+
+## Prerequisites
+
+1. For replication: source node must have the shard, target node must not (for COPY)
+2. `--shard` requires `--collection` when querying replications
+3. `--target-node` cannot be combined with `--collection` or `--shard`
+
+## Notes
+
+- Use `--minimal` for large clusters to avoid slow node enumeration
+- `delete all-replications` removes all replication operations -- use with caution
+- Replication operations are asynchronous; use `get replication` to monitor progress

--- a/.claude/skills/operating-weaviate-cli/references/collections.md
+++ b/.claude/skills/operating-weaviate-cli/references/collections.md
@@ -1,0 +1,71 @@
+# Collections Reference
+
+Manage Weaviate collections (schemas).
+
+## List All Collections
+```bash
+weaviate-cli get collection --json
+```
+
+## Get Specific Collection
+```bash
+weaviate-cli get collection --collection "CollectionName" --json
+```
+
+## Create Collection
+```bash
+weaviate-cli create collection \
+  --collection "MyCollection" \
+  --replication_factor 3 \
+  --vector_index hnsw \
+  --vectorizer none \
+  --json
+```
+
+**Full options:**
+- `--collection` -- Name (default: "Movies")
+- `--replication_factor` -- Number of replicas (default: 3)
+- `--async_enabled` -- Enable async replication
+- `--vector_index` -- Index type: hnsw, flat, dynamic, hnsw_pq, hnsw_bq, hnsw_sq, hnsw_rq, hnsw_acorn, hnsw_multivector, flat_bq, dynamic_*
+- `--inverted_index` -- Inverted index: timestamp, null, length
+- `--training_limit` -- PQ/SQ training limit (default: 10000)
+- `--multitenant` -- Enable multi-tenancy
+- `--auto_tenant_creation` -- Auto-create tenants on data ingestion
+- `--auto_tenant_activation` -- Auto-activate tenants on access
+- `--force_auto_schema` -- Let auto-schema infer properties
+- `--shards` -- Number of shards (default: 0, meaning Weaviate auto-determines)
+- `--vectorizer` -- Vectorizer: contextionary, transformers, openai, ollama, cohere, jinaai, jinaai_colbert, weaviate, weaviate-1.5, model2vec, none
+- `--vectorizer_base_url` -- Custom vectorizer URL
+- `--named_vector` -- Enable named vectors
+- `--named_vector_name` -- Named vector name (default: "default")
+- `--replication_deletion_strategy` -- delete_on_conflict, no_automated_resolution, time_based_resolution
+
+## Update Collection (mutable fields only)
+```bash
+weaviate-cli update collection \
+  --collection "MyCollection" \
+  --description "Updated description" \
+  --replication_factor 5 \
+  --json
+```
+
+Mutable fields: `--async_enabled`, `--replication_factor`, `--vector_index`, `--description`, `--training_limit`, `--auto_tenant_creation`, `--auto_tenant_activation`, `--replication_deletion_strategy`
+
+**Immutable (cannot change after creation):** multitenant, vectorizer, named_vector, shards
+
+## Delete Collection
+```bash
+weaviate-cli delete collection --collection "MyCollection" --json
+weaviate-cli delete collection --all --json
+```
+
+## Prerequisites
+
+- Weaviate cluster must be reachable
+- For RBAC clusters: user needs collection permissions
+
+## Notes
+
+- Collection names are case-sensitive
+- Deleting a collection removes all its data, tenants, and shards
+- `--all` deletes every collection -- use with caution

--- a/.claude/skills/operating-weaviate-cli/references/config-management.md
+++ b/.claude/skills/operating-weaviate-cli/references/config-management.md
@@ -1,0 +1,112 @@
+# Config Management Reference
+
+Patterns for managing weaviate-cli configuration files.
+
+## Config File Format
+
+```json
+{
+    "host": "hostname-or-ip",
+    "http_port": "8080",
+    "grpc_port": "50051",
+    "grpc_host": "optional-separate-grpc-host",
+    "auth": {
+        "type": "api_key|user",
+        "api_key": "key-for-api_key-type",
+        "user-name": "key-for-user-type"
+    }
+}
+```
+
+## Decision Tree: When to Create a Config
+
+1. **Local cluster, no auth** -- No config needed. The CLI defaults to `localhost:8080`/`50051`.
+2. **Local cluster with RBAC** -- Create a config with auth type `api_key` or `user`.
+3. **Remote cluster (Weaviate Cloud)** -- Create a config with the cluster URL and API key.
+4. **Custom host/ports** -- Create a config specifying host, ports, and optional auth.
+
+## Config File Naming Convention
+
+Store configs under `~/.config/weaviate/` with descriptive filenames:
+
+| Scenario | Filename |
+|----------|----------|
+| Default local | (none needed) |
+| Local with RBAC | `local-rbac.json` |
+| Staging cloud cluster | `cloud-staging.json` |
+| Production cloud cluster | `cloud-prod.json` |
+| Custom environment | `custom-<env>.json` |
+
+## Common Patterns
+
+### Local (no config)
+```bash
+weaviate-cli get nodes --minimal --json
+```
+
+### Local with API key auth
+```bash
+cat > ~/.config/weaviate/local-auth.json << 'EOF'
+{
+    "host": "localhost",
+    "http_port": "8080",
+    "grpc_port": "50051",
+    "auth": {
+        "type": "api_key",
+        "api_key": "admin-key"
+    }
+}
+EOF
+weaviate-cli --config-file ~/.config/weaviate/local-auth.json get nodes --minimal --json
+```
+
+### Local with RBAC (per-user auth)
+```bash
+cat > ~/.config/weaviate/local-rbac.json << 'EOF'
+{
+    "host": "localhost",
+    "http_port": "8080",
+    "grpc_port": "50051",
+    "auth": {
+        "type": "user",
+        "admin-user": "admin-key"
+    }
+}
+EOF
+weaviate-cli --config-file ~/.config/weaviate/local-rbac.json --user admin-user get nodes --minimal --json
+```
+
+### Weaviate Cloud
+```bash
+cat > ~/.config/weaviate/cloud-staging.json << 'EOF'
+{
+    "host": "https://your-cluster.weaviate.cloud",
+    "auth": {
+        "type": "api_key",
+        "api_key": "your-api-key"
+    }
+}
+EOF
+weaviate-cli --config-file ~/.config/weaviate/cloud-staging.json get nodes --minimal --json
+```
+
+## Using the In-Development CLI Version
+
+When testing code changes or validating in-dev features, activate the development venv first before running `weaviate-cli` commands:
+
+```bash
+source <weaviate-cli-repo>/.venv/bin/activate
+weaviate-cli get nodes --minimal --json
+```
+
+The user will tell you where the repo lives. Always use this venv when the task involves testing or verifying modifications to the weaviate-cli source code itself.
+
+## Rules for Agents
+
+- **Never overwrite** `~/.config/weaviate/config.json` without explicit user consent
+- Use descriptive filenames -- not generic ones
+- Always verify connectivity after creating a config
+- If the user specifies a config file path, use it exactly
+- If no config is specified, assume local defaults (no `--config-file` flag)
+- When creating a user with `--store`, the API key is saved into the active config file
+- When testing in-dev features, source the repo's `.venv/bin/activate` before running commands

--- a/.claude/skills/operating-weaviate-cli/references/data.md
+++ b/.claude/skills/operating-weaviate-cli/references/data.md
@@ -1,0 +1,58 @@
+# Data Reference
+
+Ingest, update, or delete data in Weaviate collections.
+
+## Ingest Data
+```bash
+weaviate-cli create data \
+  --collection "Movies" \
+  --limit 1000 \
+  --randomize \
+  --json
+```
+
+**Options:**
+- `--collection` -- Target collection (default: "Movies")
+- `--limit` -- Number of objects (default: 1000)
+- `--consistency_level` -- quorum, all, one (default: quorum)
+- `--randomize` -- Generate random data
+- `--skip-seed` -- Skip seeding random data
+- `--vector_dimensions` -- Dimensions for random vectors (default: 1536, requires --randomize)
+- `--uuid` -- Specific UUID (requires --randomize and --limit=1)
+- `--batch_size` -- Objects per batch (default: 1000)
+- `--concurrent_requests` -- Parallel requests (default: CPU+4, max 32)
+- `--multi_vector` -- Enable multi-vector ingestion
+- `--dynamic_batch` -- Enable dynamic batching (requires --randomize)
+- `--wait_for_indexing` -- Wait for indexing to complete
+- `--verbose` -- Show detailed progress
+
+**Multi-tenant ingestion:**
+- `--auto_tenants N` -- Send data to N auto-created tenants (requires collection with --auto_tenant_creation)
+- `--tenants "T1,T2"` -- Send data to specific tenants
+- `--tenant_suffix` -- Prefix for auto-tenant names (default: "Tenant")
+
+## Update Data
+```bash
+weaviate-cli update data --collection "Movies" --limit 100 --randomize --json
+```
+
+## Delete Data
+```bash
+weaviate-cli delete data --collection "Movies" --limit 100 --json
+weaviate-cli delete data --collection "Movies" --uuid "abc-123" --json
+weaviate-cli delete data --collection "Movies" --tenants "T1,T2" --limit 50 --json
+```
+
+## Prerequisites
+
+1. **Collection must exist** -- run `create collection` first
+2. **For multi-tenant collections:** tenants must exist OR `--auto_tenant_creation` must be enabled on the collection
+3. **For multi-tenant data ingestion:** tenants must be in `hot`/`active` state
+4. **For vectorizer-based ingestion (non-randomize):** the collection uses a built-in dataset; vectorizer API keys may be needed
+
+## Notes
+
+- `--randomize` generates synthetic data with random vectors -- useful for testing
+- Without `--randomize`, the CLI uses a built-in Movies dataset
+- `--uuid` is only valid with `--randomize` and `--limit=1`
+- `--dynamic_batch` is only valid with `--randomize`

--- a/.claude/skills/operating-weaviate-cli/references/rbac.md
+++ b/.claude/skills/operating-weaviate-cli/references/rbac.md
@@ -1,0 +1,112 @@
+# RBAC (Roles, Users, Permissions) Reference
+
+Manage role-based access control in Weaviate.
+
+## Complete RBAC Setup
+```bash
+# 1. Create a role with permissions
+weaviate-cli create role --role_name MoviesAdmin \
+  -p crud_collections:Movies \
+  -p crud_data:Movies \
+  -p crud_tenants:Movies \
+  --json
+
+# 2. Create a user (returns API key)
+weaviate-cli create user --user_name test-user --json
+
+# 3. Assign role to user (supports multiple --role_name)
+weaviate-cli assign role --role_name MoviesAdmin --user_name test-user --json
+weaviate-cli assign role --role_name MoviesAdmin --role_name TenantAdmin --user_name test-user --json
+
+# 4. Verify
+weaviate-cli get role --role_name MoviesAdmin --json
+weaviate-cli get user --user_name test-user --json
+```
+
+## Inspect Roles
+```bash
+weaviate-cli get role --all --json                              # All roles
+weaviate-cli get role --role_name MoviesAdmin --json            # Specific role
+weaviate-cli get role --user_name test-user --json              # Roles of a user
+weaviate-cli get role --user_name oidc-user --user_type oidc --json  # OIDC user's roles
+```
+
+## Inspect Users
+```bash
+weaviate-cli get user --json                                    # Current user
+weaviate-cli get user --all --json                              # All users
+weaviate-cli get user --user_name test-user --json              # Specific user
+weaviate-cli get user --role_name MoviesAdmin --json            # Users with role
+```
+
+## Modify Permissions
+```bash
+weaviate-cli assign permission -p read_data:Movies --role_name MoviesAdmin --json
+weaviate-cli revoke permission -p read_data:Movies --role_name MoviesAdmin --json
+```
+
+## Manage User Lifecycle
+```bash
+weaviate-cli create user --user_name test-user --store --json   # Create and store API key in config
+weaviate-cli update user --user_name test-user --rotate_api_key --json
+weaviate-cli update user --user_name test-user --rotate_api_key --store --json  # Rotate and store
+weaviate-cli update user --user_name test-user --deactivate --json
+weaviate-cli update user --user_name test-user --activate --json
+weaviate-cli delete user --user_name test-user --json
+```
+
+## Cleanup
+```bash
+weaviate-cli revoke role --role_name MoviesAdmin --user_name test-user --json
+weaviate-cli revoke role --role_name MoviesAdmin --user_name oidc-user --user_type oidc --json  # OIDC user
+weaviate-cli delete role --role_name MoviesAdmin --json
+weaviate-cli delete user --user_name test-user --json
+```
+
+## Permission Format
+
+Permissions use the format `action:target`. Multiple permissions can be specified with repeated `-p` flags.
+
+**Available actions:**
+
+| Category | Actions |
+|----------|---------|
+| Collections | `create_collections`, `read_collections`, `update_collections`, `delete_collections` |
+| Data | `create_data`, `read_data`, `update_data`, `delete_data` |
+| Tenants | `create_tenants`, `read_tenants`, `update_tenants`, `delete_tenants` |
+| Roles | `create_roles`, `read_roles`, `update_roles`, `delete_roles` |
+| Users | `assign_and_revoke_users`, `read_users` |
+| Aliases | `create_aliases`, `read_aliases`, `update_aliases`, `delete_aliases` |
+| Cluster | `read_cluster` |
+| Nodes | `read_nodes` |
+| Backups | `manage_backups` |
+
+**CRUD shorthands:** `crud_collections`, `crud_data`, `crud_tenants`, `crud_roles`, `crud_users`, `crud_aliases`, `cud_data`, `rd_data`, `cud_tenants`, `rd_tenants`, `rd_collections`, `cud_aliases`, `rd_aliases`
+
+Any combination of `c`, `r`, `u`, `d` prefix letters works (e.g., `cr_collections` for create+read).
+
+**Examples:**
+```
+-p crud_collections:Movies
+-p cud_tenants:Person_*
+-p crud_data:Movies,Books
+-p crud_tenants:Movies,Books:MyTenant*,YourTenant*
+-p read_nodes:verbose:Movies
+-p read_nodes:minimal
+-p manage_backups:Movies
+-p read_cluster
+```
+
+## Prerequisites
+
+1. Cluster must have RBAC enabled
+2. Connecting user must have sufficient permissions to manage roles/users
+3. For `--user` global option: config must have auth type `user`
+
+## Notes
+
+- `create user` returns an API key -- save it, as it cannot be retrieved later
+- `--store` saves the API key in the config file (requires auth type `user`)
+- `--user_type` defaults to `db`; use `oidc` for OIDC-authenticated users (applies to `get role`, `assign role`, `revoke role`)
+- `--role_name` supports `multiple=True` for `assign role` and `revoke role` (assign/revoke multiple roles at once)
+- Role names and user names are case-sensitive

--- a/.claude/skills/operating-weaviate-cli/references/search.md
+++ b/.claude/skills/operating-weaviate-cli/references/search.md
@@ -1,0 +1,62 @@
+# Search / Query Data Reference
+
+Query data in Weaviate collections using various search strategies.
+
+## Fetch (no search, just retrieve objects)
+```bash
+weaviate-cli query data --collection "Movies" --search_type fetch --limit 10 --json
+```
+
+## Vector Search (near_text)
+```bash
+weaviate-cli query data --collection "Movies" --search_type vector --query "Action movie" --limit 10 --json
+```
+Requires a vectorizer configured on the collection.
+
+## Keyword Search (BM25)
+```bash
+weaviate-cli query data --collection "Movies" --search_type keyword --query "Action movie" --limit 10 --json
+```
+
+## Hybrid Search (vector + keyword)
+```bash
+weaviate-cli query data --collection "Movies" --search_type hybrid --query "Action movie" --limit 10 --json
+```
+
+## UUID Search
+```bash
+weaviate-cli query data --collection "Movies" --search_type uuid --query "abc-123-def" --limit 1 --json
+```
+
+## Options
+
+- `--collection` -- Collection to query (default: "Movies")
+- `--search_type` -- fetch, vector, keyword, hybrid, uuid (default: fetch)
+- `--query` -- Search query text (default: "Action movie")
+- `--limit` -- Number of results (default: 10)
+- `--properties` -- Properties to display (default: "title,keywords")
+- `--consistency_level` -- quorum, all, one (default: quorum)
+- `--tenants` -- Comma-separated tenants to query
+- `--target_vector` -- Named vector to target
+
+## Search Type Selection Guide
+
+| Goal | Search Type |
+|------|-------------|
+| Browse/list objects | `fetch` |
+| Find conceptually similar content | `vector` |
+| Find exact terms or IDs | `keyword` |
+| Best general-purpose search | `hybrid` |
+| Retrieve specific object by UUID | `uuid` |
+
+## Prerequisites
+
+1. Collection must exist with data
+2. For `vector` and `hybrid`: collection needs a vectorizer (or vectors must be stored)
+3. For multi-tenant queries: specify `--tenants`
+
+## Notes
+
+- `--json` returns objects with uuid, properties, distance, certainty, and score fields
+- `fetch` does not use the `--query` parameter
+- `uuid` search ignores `--limit` (always returns 0 or 1 result)

--- a/.claude/skills/operating-weaviate-cli/references/tenants.md
+++ b/.claude/skills/operating-weaviate-cli/references/tenants.md
@@ -1,0 +1,70 @@
+# Tenants Reference
+
+Manage tenants in multi-tenant Weaviate collections.
+
+## Create Tenants
+```bash
+weaviate-cli create tenants \
+  --collection "Movies" \
+  --number_tenants 100 \
+  --tenant_suffix "Tenant" \
+  --state active \
+  --json
+```
+Creates tenants named `Tenant-0` through `Tenant-99`.
+
+Options: `--tenant_batch_size N` for batched creation.
+
+## Get Tenants
+```bash
+weaviate-cli get tenants --collection "Movies" --json
+weaviate-cli get tenants --collection "Movies" --tenant_id "Tenant-1" --verbose --json
+```
+
+## Update Tenant State
+```bash
+weaviate-cli update tenants --collection "Movies" --state cold --number_tenants 100 --json
+weaviate-cli update tenants --collection "Movies" --state hot --tenants "Tenant-1,Tenant-2" --json
+```
+
+## Delete Tenants
+```bash
+weaviate-cli delete tenants --collection "Movies" --number_tenants 100 --json
+weaviate-cli delete tenants --collection "Movies" --tenants "Tenant-1,Tenant-2" --json
+weaviate-cli delete tenants --collection "Movies" --tenant_suffix "*" --number_tenants 50 --json
+```
+
+Using `--tenant_suffix "*"` ignores the suffix pattern and selects from **all** existing tenants regardless of name. It then deletes up to `--number_tenants` of them. Use with caution as it may delete tenants with any name.
+
+## Tenant State Machine
+
+```
+hot/active  <-->  cold/inactive
+    ^   \              ^
+    |    \             |
+    v     v            v
+      frozen/offloaded
+```
+
+| State | Aliases | Description |
+|-------|---------|-------------|
+| `hot` / `active` | Equivalent | Data in memory, queryable, accepts writes |
+| `cold` / `inactive` | Equivalent | Data on disk, not queryable |
+| `frozen` / `offloaded` | Equivalent | Data in cloud storage, not queryable |
+
+- Tenants can be offloaded directly from `hot`/`active` or from `cold`/`inactive`
+- Tenants can be activated back to `hot` from any state
+- Data operations (create/query/update/delete data) require `hot`/`active` state
+- Transitioning to `hot` from `frozen` may take time (download from cloud storage)
+
+## Prerequisites
+
+1. Collection must exist with `--multitenant` enabled
+2. For state transitions: tenants must already exist
+3. For data operations on tenants: tenants must be in `hot`/`active` state
+
+## Notes
+
+- Tenant names are case-sensitive
+- The `--tenant_suffix` default is "Tenant", creating names like "Tenant-0", "Tenant-1", etc.
+- Deleting tenants also deletes all data within them

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# weaviate-cli
+
+CLI tool for managing Weaviate vector databases. Built with Python + Click.
+
+## Quick Start
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+make install-dev    # Install deps + pre-commit hooks
+make test           # Run unit tests
+```
+
+## Development Commands
+
+| Command | What it does |
+|---------|-------------|
+| `make format` | Black formatter on cli.py, weaviate_cli/, test/ |
+| `make lint` | Black --check (CI-equivalent) |
+| `make test` | pytest test/unittests |
+| `make build-all` | Build package + twine check |
+| `make all` | format + lint + test + build-all |
+
+## Architecture
+
+`cli.py` (Click group) -> `weaviate_cli/commands/` (Click decorators) -> `weaviate_cli/managers/` (business logic)
+
+- **defaults.py**: Dataclass defaults for every command (always reference these, never hardcode)
+- **utils.py**: `get_client_from_context()`, `print_json_or_text()`, `parse_permission()`
+- **ConfigManager**: Created once in `cli.py`, stored in `ctx.obj["config"]`
+
+## Key Conventions
+
+- Every command **must** have `--json` support (parameter named `json_output`)
+- Defaults live in `defaults.py` as dataclasses
+- Black formatting (default settings, 88 char line length)
+- Client lifecycle: get in `try`, close in `finally`, `sys.exit(1)` on error
+- Error format: `click.echo(f"Error: {e}")`
+
+## Testing
+
+- **Unit tests**: `test/unittests/` -- CliRunner for CLI, MagicMock for managers
+- **Integration tests**: `test/integration/` -- requires running Weaviate cluster
+- **CI**: lint -> unit tests (Python 3.9-3.13) -> integration tests (latest Weaviate)
+
+## Agent Skills
+
+Skills live in `.claude/skills/`:
+- `operating-weaviate-cli/` -- Using the CLI to manage Weaviate clusters
+- `contributing-to-weaviate-cli/` -- Developing and testing the CLI codebase
+
+When adding new commands or options, update both the code and the relevant skill documentation.

--- a/test/unittests/test_managers/test_backup_manager.py
+++ b/test/unittests/test_managers/test_backup_manager.py
@@ -1,0 +1,594 @@
+import json
+import pytest
+from unittest.mock import MagicMock
+
+from weaviate_cli.managers.backup_manager import BackupManager
+
+
+@pytest.fixture
+def mock_client_with_backup(mock_client: MagicMock) -> MagicMock:
+    """
+    Configures mock_client with sensible defaults for BackupManager tests.
+    - get_meta returns a version > 1.25.0 so BackupConfigCreate is used.
+    - collections.exists returns True by default.
+    - backup.create returns a SUCCESS result by default.
+
+    Collections and backup are assigned as plain MagicMocks (not spec-constrained)
+    so that attribute access like .exists and .create is freely allowed.
+    """
+    mock_client.get_meta.return_value = {"version": "1.26.0"}
+
+    mock_collections = MagicMock()
+    mock_collections.exists.return_value = True
+    mock_client.collections = mock_collections
+
+    mock_backup = MagicMock()
+    mock_backup.create.return_value = MagicMock(status=MagicMock(value="SUCCESS"))
+    mock_backup.restore.return_value = MagicMock(status=MagicMock(value="SUCCESS"))
+    mock_client.backup = mock_backup
+
+    return mock_client
+
+
+@pytest.fixture
+def backup_manager(mock_client_with_backup: MagicMock) -> BackupManager:
+    """
+    Returns a BackupManager instance using a fully configured mock client.
+    """
+    return BackupManager(mock_client_with_backup)
+
+
+# ---------------------------------------------------------------------------
+# create_backup — collection existence checks
+# ---------------------------------------------------------------------------
+
+
+def test_create_backup_include_collection_not_found(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock
+) -> None:
+    """
+    create_backup raises when a collection in `include` does not exist.
+    """
+    mock_client_with_backup.collections.exists.return_value = False
+
+    with pytest.raises(Exception) as exc_info:
+        backup_manager.create_backup(
+            backup_id="my-backup",
+            backend="s3",
+            include="NonExistentCollection",
+        )
+
+    assert "NonExistentCollection" in str(exc_info.value)
+    assert "does not exist" in str(exc_info.value)
+    assert "include" in str(exc_info.value)
+
+
+def test_create_backup_include_one_collection_missing_among_multiple(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock
+) -> None:
+    """
+    create_backup raises when only one collection among multiple in `include` does not exist.
+    """
+    mock_client_with_backup.collections.exists.side_effect = [True, False]
+
+    with pytest.raises(Exception) as exc_info:
+        backup_manager.create_backup(
+            backup_id="my-backup",
+            backend="s3",
+            include="ExistingCollection,MissingCollection",
+        )
+
+    assert "MissingCollection" in str(exc_info.value)
+    assert "does not exist" in str(exc_info.value)
+
+
+def test_create_backup_exclude_collection_not_found(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock
+) -> None:
+    """
+    create_backup raises when a collection in `exclude` does not exist.
+    """
+    mock_client_with_backup.collections.exists.return_value = False
+
+    with pytest.raises(Exception) as exc_info:
+        backup_manager.create_backup(
+            backup_id="my-backup",
+            backend="s3",
+            exclude="NonExistentCollection",
+        )
+
+    assert "NonExistentCollection" in str(exc_info.value)
+    assert "does not exist" in str(exc_info.value)
+    assert "exclude" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# create_backup — success without wait
+# ---------------------------------------------------------------------------
+
+
+def test_create_backup_no_wait_text_output(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock, capsys
+) -> None:
+    """
+    create_backup without wait emits text success message and does not check result status.
+    """
+    backup_manager.create_backup(
+        backup_id="my-backup",
+        backend="s3",
+        wait=False,
+        json_output=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "my-backup" in out
+    assert "created successfully" in out
+
+
+def test_create_backup_no_wait_json_output(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock, capsys
+) -> None:
+    """
+    create_backup without wait and json_output=True emits JSON with status=success.
+    """
+    backup_manager.create_backup(
+        backup_id="my-backup",
+        backend="s3",
+        wait=False,
+        json_output=True,
+    )
+
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["status"] == "success"
+    assert "my-backup" in data["message"]
+
+
+# ---------------------------------------------------------------------------
+# create_backup — with wait
+# ---------------------------------------------------------------------------
+
+
+def test_create_backup_with_wait_success(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock, capsys
+) -> None:
+    """
+    create_backup with wait=True and result.status.value == "SUCCESS" emits success message.
+    """
+    mock_client_with_backup.backup.create.return_value = MagicMock(
+        status=MagicMock(value="SUCCESS")
+    )
+
+    backup_manager.create_backup(
+        backup_id="my-backup",
+        backend="s3",
+        wait=True,
+        json_output=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "my-backup" in out
+    assert "created successfully" in out
+
+
+def test_create_backup_with_wait_non_success_raises(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock
+) -> None:
+    """
+    create_backup with wait=True and result.status.value != "SUCCESS" raises an exception.
+    """
+    mock_client_with_backup.backup.create.return_value = MagicMock(
+        status=MagicMock(value="FAILED")
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        backup_manager.create_backup(
+            backup_id="my-backup",
+            backend="s3",
+            wait=True,
+        )
+
+    assert "my-backup" in str(exc_info.value)
+    assert "FAILED" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# create_backup — argument passing
+# ---------------------------------------------------------------------------
+
+
+def test_create_backup_passes_correct_args_with_include(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock
+) -> None:
+    """
+    create_backup passes include_collections as a split list to client.backup.create.
+    """
+    backup_manager.create_backup(
+        backup_id="my-backup",
+        backend="gcs",
+        include="CollectionA,CollectionB",
+        wait=False,
+    )
+
+    mock_client_with_backup.backup.create.assert_called_once()
+    call_kwargs = mock_client_with_backup.backup.create.call_args.kwargs
+    assert call_kwargs["backup_id"] == "my-backup"
+    assert call_kwargs["backend"] == "gcs"
+    assert call_kwargs["include_collections"] == ["CollectionA", "CollectionB"]
+    assert call_kwargs["exclude_collections"] is None
+    assert call_kwargs["wait_for_completion"] is False
+
+
+def test_create_backup_passes_correct_args_with_exclude(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock
+) -> None:
+    """
+    create_backup passes exclude_collections as a split list and include_collections=None.
+    """
+    backup_manager.create_backup(
+        backup_id="my-backup",
+        backend="s3",
+        exclude="CollectionX,CollectionY",
+        wait=False,
+    )
+
+    call_kwargs = mock_client_with_backup.backup.create.call_args.kwargs
+    assert call_kwargs["include_collections"] is None
+    assert call_kwargs["exclude_collections"] == ["CollectionX", "CollectionY"]
+
+
+def test_create_backup_passes_none_collections_when_not_specified(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock
+) -> None:
+    """
+    create_backup passes None for both collection args when neither is specified.
+    """
+    backup_manager.create_backup(backup_id="my-backup", backend="s3")
+
+    call_kwargs = mock_client_with_backup.backup.create.call_args.kwargs
+    assert call_kwargs["include_collections"] is None
+    assert call_kwargs["exclude_collections"] is None
+
+
+# ---------------------------------------------------------------------------
+# restore_backup — success without wait
+# ---------------------------------------------------------------------------
+
+
+def test_restore_backup_no_wait_text_output(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock, capsys
+) -> None:
+    """
+    restore_backup without wait emits text success message.
+    """
+    backup_manager.restore_backup(
+        backup_id="my-backup",
+        backend="s3",
+        wait=False,
+        json_output=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "my-backup" in out
+    assert "restored successfully" in out
+
+
+def test_restore_backup_no_wait_json_output(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock, capsys
+) -> None:
+    """
+    restore_backup without wait and json_output=True emits JSON with status=success.
+    """
+    backup_manager.restore_backup(
+        backup_id="my-backup",
+        backend="s3",
+        wait=False,
+        json_output=True,
+    )
+
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["status"] == "success"
+    assert "my-backup" in data["message"]
+
+
+# ---------------------------------------------------------------------------
+# restore_backup — with wait
+# ---------------------------------------------------------------------------
+
+
+def test_restore_backup_with_wait_success(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock, capsys
+) -> None:
+    """
+    restore_backup with wait=True and SUCCESS status emits success message.
+    """
+    mock_client_with_backup.backup.restore.return_value = MagicMock(
+        status=MagicMock(value="SUCCESS")
+    )
+
+    backup_manager.restore_backup(
+        backup_id="my-backup",
+        backend="s3",
+        wait=True,
+        json_output=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "my-backup" in out
+    assert "restored successfully" in out
+
+
+def test_restore_backup_with_wait_non_success_raises(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock
+) -> None:
+    """
+    restore_backup with wait=True and non-SUCCESS status raises an exception.
+    """
+    mock_client_with_backup.backup.restore.return_value = MagicMock(
+        status=MagicMock(value="FAILED")
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        backup_manager.restore_backup(
+            backup_id="my-backup",
+            backend="s3",
+            wait=True,
+        )
+
+    assert "my-backup" in str(exc_info.value)
+    assert "FAILED" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# get_backup — restore=True (get_restore_status)
+# ---------------------------------------------------------------------------
+
+
+def _make_backup_status_mock(
+    backup_id: str = "my-backup",
+    path: str = "/backups/my-backup",
+    status: str = "SUCCESS",
+) -> MagicMock:
+    """
+    Creates a mock backup status object without dict-like 'collections' key support.
+
+    The production code checks `if "collections" in backup`, which calls __contains__.
+    We use a plain MagicMock (no spec) and configure __contains__ to return False so
+    that the `collections` branch is skipped, keeping the output predictable.
+    """
+    mock_status = MagicMock()
+    mock_status.backup_id = backup_id
+    mock_status.path = path
+    mock_status.status = status
+    mock_status.__contains__ = MagicMock(return_value=False)
+    return mock_status
+
+
+def test_get_backup_restore_true_text_output(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock, capsys
+) -> None:
+    """
+    get_backup with restore=True calls get_restore_status and prints text output.
+    """
+    mock_status = _make_backup_status_mock()
+    mock_client_with_backup.backup.get_restore_status.return_value = mock_status
+
+    backup_manager.get_backup(
+        backend="s3",
+        backup_id="my-backup",
+        restore=True,
+        json_output=False,
+    )
+
+    mock_client_with_backup.backup.get_restore_status.assert_called_once_with(
+        backup_id="my-backup",
+        backend="s3",
+    )
+    out = capsys.readouterr().out
+    assert "my-backup" in out
+    assert "/backups/my-backup" in out
+    assert "SUCCESS" in out
+
+
+def test_get_backup_restore_true_json_output(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock, capsys
+) -> None:
+    """
+    get_backup with restore=True and json_output=True emits JSON.
+    """
+    mock_status = _make_backup_status_mock()
+    mock_client_with_backup.backup.get_restore_status.return_value = mock_status
+
+    backup_manager.get_backup(
+        backend="s3",
+        backup_id="my-backup",
+        restore=True,
+        json_output=True,
+    )
+
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["backup_id"] == "my-backup"
+    assert data["path"] == "/backups/my-backup"
+    assert "SUCCESS" in data["status"]
+
+
+def test_get_backup_restore_true_does_not_call_get_create_status(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock, capsys
+) -> None:
+    """
+    get_backup with restore=True never calls get_create_status.
+    """
+    mock_status = _make_backup_status_mock()
+    mock_client_with_backup.backup.get_restore_status.return_value = mock_status
+
+    backup_manager.get_backup(
+        backend="s3",
+        backup_id="my-backup",
+        restore=True,
+    )
+
+    mock_client_with_backup.backup.get_create_status.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# get_backup — restore=False with backup_id (get_create_status)
+# ---------------------------------------------------------------------------
+
+
+def test_get_backup_restore_false_with_id_text_output(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock, capsys
+) -> None:
+    """
+    get_backup with restore=False and a backup_id calls get_create_status and prints text.
+    """
+    mock_status = _make_backup_status_mock()
+    mock_client_with_backup.backup.get_create_status.return_value = mock_status
+
+    backup_manager.get_backup(
+        backend="s3",
+        backup_id="my-backup",
+        restore=False,
+        json_output=False,
+    )
+
+    mock_client_with_backup.backup.get_create_status.assert_called_once_with(
+        backup_id="my-backup",
+        backend="s3",
+    )
+    out = capsys.readouterr().out
+    assert "my-backup" in out
+    assert "/backups/my-backup" in out
+    assert "SUCCESS" in out
+
+
+def test_get_backup_restore_false_with_id_json_output(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock, capsys
+) -> None:
+    """
+    get_backup with restore=False and a backup_id and json_output=True emits JSON.
+    """
+    mock_status = _make_backup_status_mock()
+    mock_client_with_backup.backup.get_create_status.return_value = mock_status
+
+    backup_manager.get_backup(
+        backend="s3",
+        backup_id="my-backup",
+        restore=False,
+        json_output=True,
+    )
+
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["backup_id"] == "my-backup"
+    assert data["path"] == "/backups/my-backup"
+    assert "SUCCESS" in data["status"]
+
+
+def test_get_backup_restore_false_with_id_does_not_call_get_restore_status(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock, capsys
+) -> None:
+    """
+    get_backup with restore=False never calls get_restore_status.
+    """
+    mock_status = _make_backup_status_mock()
+    mock_client_with_backup.backup.get_create_status.return_value = mock_status
+
+    backup_manager.get_backup(
+        backend="s3",
+        backup_id="my-backup",
+        restore=False,
+    )
+
+    mock_client_with_backup.backup.get_restore_status.assert_not_called()
+
+
+def test_get_backup_restore_false_no_backup_id_raises(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock
+) -> None:
+    """
+    get_backup with restore=False and backup_id=None raises an unsupported exception.
+    """
+    with pytest.raises(Exception) as exc_info:
+        backup_manager.get_backup(
+            backend="s3",
+            backup_id=None,
+            restore=False,
+        )
+
+    assert "not supported" in str(exc_info.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# cancel_backup — success
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_backup_returns_true_text_output(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock, capsys
+) -> None:
+    """
+    cancel_backup when client.backup.cancel() returns True emits text success message.
+    """
+    mock_client_with_backup.backup.cancel.return_value = True
+
+    backup_manager.cancel_backup(
+        backend="s3",
+        backup_id="my-backup",
+        json_output=False,
+    )
+
+    mock_client_with_backup.backup.cancel.assert_called_once_with(
+        backend="s3",
+        backup_id="my-backup",
+    )
+    out = capsys.readouterr().out
+    assert "my-backup" in out
+    assert "cancelled successfully" in out
+
+
+def test_cancel_backup_returns_true_json_output(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock, capsys
+) -> None:
+    """
+    cancel_backup when client.backup.cancel() returns True and json_output=True emits JSON.
+    """
+    mock_client_with_backup.backup.cancel.return_value = True
+
+    backup_manager.cancel_backup(
+        backend="s3",
+        backup_id="my-backup",
+        json_output=True,
+    )
+
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["status"] == "success"
+    assert "my-backup" in data["message"]
+
+
+# ---------------------------------------------------------------------------
+# cancel_backup — failure
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_backup_returns_false_raises(
+    backup_manager: BackupManager, mock_client_with_backup: MagicMock
+) -> None:
+    """
+    cancel_backup when client.backup.cancel() returns False raises an exception with current status.
+    """
+    mock_client_with_backup.backup.cancel.return_value = False
+    mock_status = MagicMock()
+    mock_status.status = "STARTED"
+    mock_client_with_backup.backup.get_create_status.return_value = mock_status
+
+    with pytest.raises(Exception) as exc_info:
+        backup_manager.cancel_backup(
+            backend="s3",
+            backup_id="my-backup",
+        )
+
+    assert "my-backup" in str(exc_info.value)
+    assert "could not be cancelled" in str(exc_info.value)

--- a/test/unittests/test_managers/test_cluster_manager.py
+++ b/test/unittests/test_managers/test_cluster_manager.py
@@ -1,0 +1,518 @@
+import json
+import pytest
+from unittest.mock import MagicMock, call
+
+from weaviate_cli.managers.cluster_manager import ClusterManager
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_rep(
+    uuid="test-uuid-1234",
+    transfer_type_value="COPY",
+    collection="Movies",
+    shard="shard1",
+    source_node="node0",
+    target_node="node1",
+    state_value="READY",
+    errors=None,
+    status_history=None,
+):
+    """Build a MagicMock replication object with the expected attribute shape."""
+    rep = MagicMock()
+    rep.uuid = uuid
+    rep.transfer_type.value = transfer_type_value
+    rep.collection = collection
+    rep.shard = shard
+    rep.source_node = source_node
+    rep.target_node = target_node
+    rep.status.state.value = state_value
+    rep.status.errors = errors if errors is not None else []
+    rep.status_history = status_history
+    return rep
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def output_lines():
+    """A list that accumulates lines emitted by the printer callable."""
+    return []
+
+
+@pytest.fixture
+def cluster_manager(mock_client: MagicMock, output_lines: list) -> ClusterManager:
+    """ClusterManager wired to a mocked client and a capturing printer."""
+    mock_client.cluster = MagicMock()
+    return ClusterManager(mock_client, printer=output_lines.append)
+
+
+# ---------------------------------------------------------------------------
+# start_replication
+# ---------------------------------------------------------------------------
+
+
+def test_start_replication_success(
+    cluster_manager: ClusterManager, mock_client: MagicMock
+) -> None:
+    """start_replication returns a UUID string on success."""
+    expected_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    mock_client.cluster.replicate.return_value = expected_uuid
+
+    result = cluster_manager.start_replication(
+        collection="Movies",
+        shard="shard0",
+        source_node="node0",
+        target_node="node1",
+        type_="COPY",
+    )
+
+    assert result == expected_uuid
+    mock_client.cluster.replicate.assert_called_once()
+
+
+def test_start_replication_error(
+    cluster_manager: ClusterManager, mock_client: MagicMock
+) -> None:
+    """start_replication wraps client errors with a descriptive message."""
+    mock_client.cluster.replicate.side_effect = Exception("network failure")
+
+    with pytest.raises(Exception) as exc_info:
+        cluster_manager.start_replication(
+            collection="Movies",
+            shard="shard0",
+            source_node="node0",
+            target_node="node1",
+            type_="COPY",
+        )
+
+    assert "Error starting replication" in str(exc_info.value)
+    assert "network failure" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# delete_replication
+# ---------------------------------------------------------------------------
+
+
+def test_delete_replication_success(
+    cluster_manager: ClusterManager, mock_client: MagicMock
+) -> None:
+    """delete_replication calls client.cluster.replications.delete with the uuid."""
+    op_id = "test-op-id"
+
+    cluster_manager.delete_replication(op_id)
+
+    mock_client.cluster.replications.delete.assert_called_once_with(uuid=op_id)
+
+
+def test_delete_replication_error(
+    cluster_manager: ClusterManager, mock_client: MagicMock
+) -> None:
+    """delete_replication raises with the uuid and original message on error."""
+    op_id = "bad-op-id"
+    mock_client.cluster.replications.delete.side_effect = Exception("not found")
+
+    with pytest.raises(Exception) as exc_info:
+        cluster_manager.delete_replication(op_id)
+
+    assert f"Error deleting replication with UUID '{op_id}'" in str(exc_info.value)
+    assert "not found" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# delete_all_replication
+# ---------------------------------------------------------------------------
+
+
+def test_delete_all_replication_success(
+    cluster_manager: ClusterManager, mock_client: MagicMock
+) -> None:
+    """delete_all_replication calls client.cluster.replications.delete_all."""
+    cluster_manager.delete_all_replication()
+
+    mock_client.cluster.replications.delete_all.assert_called_once_with()
+
+
+def test_delete_all_replication_error(
+    cluster_manager: ClusterManager, mock_client: MagicMock
+) -> None:
+    """delete_all_replication raises with a descriptive message on error."""
+    mock_client.cluster.replications.delete_all.side_effect = Exception("server error")
+
+    with pytest.raises(Exception) as exc_info:
+        cluster_manager.delete_all_replication()
+
+    assert "Error deleting all replications" in str(exc_info.value)
+    assert "server error" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# cancel_replication
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_replication_success(
+    cluster_manager: ClusterManager, mock_client: MagicMock
+) -> None:
+    """cancel_replication calls client.cluster.replications.cancel with the uuid."""
+    op_id = "cancel-op-id"
+
+    cluster_manager.cancel_replication(op_id)
+
+    mock_client.cluster.replications.cancel.assert_called_once_with(uuid=op_id)
+
+
+def test_cancel_replication_error(
+    cluster_manager: ClusterManager, mock_client: MagicMock
+) -> None:
+    """cancel_replication raises with the uuid and original message on error."""
+    op_id = "bad-cancel-id"
+    mock_client.cluster.replications.cancel.side_effect = Exception("timed out")
+
+    with pytest.raises(Exception) as exc_info:
+        cluster_manager.cancel_replication(op_id)
+
+    assert f"Error cancelling replication with UUID '{op_id}'" in str(exc_info.value)
+    assert "timed out" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# get_replication
+# ---------------------------------------------------------------------------
+
+
+def test_get_replication_success(
+    cluster_manager: ClusterManager, mock_client: MagicMock
+) -> None:
+    """get_replication returns the object returned by the client."""
+    op_id = "get-op-id"
+    expected = _make_rep(uuid=op_id)
+    mock_client.cluster.replications.get.return_value = expected
+
+    result = cluster_manager.get_replication(op_id, include_history=False)
+
+    assert result is expected
+    mock_client.cluster.replications.get.assert_called_once_with(
+        uuid=op_id, include_history=False
+    )
+
+
+def test_get_replication_with_history(
+    cluster_manager: ClusterManager, mock_client: MagicMock
+) -> None:
+    """get_replication passes include_history=True to the client."""
+    op_id = "get-op-id-history"
+    expected = _make_rep(uuid=op_id)
+    mock_client.cluster.replications.get.return_value = expected
+
+    result = cluster_manager.get_replication(op_id, include_history=True)
+
+    assert result is expected
+    mock_client.cluster.replications.get.assert_called_once_with(
+        uuid=op_id, include_history=True
+    )
+
+
+def test_get_replication_error(
+    cluster_manager: ClusterManager, mock_client: MagicMock
+) -> None:
+    """get_replication raises with the uuid and original message on error."""
+    op_id = "missing-id"
+    mock_client.cluster.replications.get.side_effect = Exception("not found")
+
+    with pytest.raises(Exception) as exc_info:
+        cluster_manager.get_replication(op_id, include_history=False)
+
+    assert f"Error getting replication with UUID '{op_id}'" in str(exc_info.value)
+    assert "not found" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# get_all_replications
+# ---------------------------------------------------------------------------
+
+
+def test_get_all_replications_success(
+    cluster_manager: ClusterManager, mock_client: MagicMock
+) -> None:
+    """get_all_replications returns the list returned by the client."""
+    expected = [_make_rep(uuid="uuid-1"), _make_rep(uuid="uuid-2")]
+    mock_client.cluster.replications.list_all.return_value = expected
+
+    result = cluster_manager.get_all_replications()
+
+    assert result is expected
+    mock_client.cluster.replications.list_all.assert_called_once_with()
+
+
+def test_get_all_replications_empty(
+    cluster_manager: ClusterManager, mock_client: MagicMock
+) -> None:
+    """get_all_replications returns an empty list when there are no replications."""
+    mock_client.cluster.replications.list_all.return_value = []
+
+    result = cluster_manager.get_all_replications()
+
+    assert result == []
+
+
+def test_get_all_replications_error(
+    cluster_manager: ClusterManager, mock_client: MagicMock
+) -> None:
+    """get_all_replications raises with a descriptive message on error."""
+    mock_client.cluster.replications.list_all.side_effect = Exception("cluster down")
+
+    with pytest.raises(Exception) as exc_info:
+        cluster_manager.get_all_replications()
+
+    assert "Error getting replications" in str(exc_info.value)
+    assert "cluster down" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# print_replication — text output
+# ---------------------------------------------------------------------------
+
+
+def test_print_replication_text_basic(
+    cluster_manager: ClusterManager, output_lines: list
+) -> None:
+    """print_replication emits all core fields via the printer."""
+    rep = _make_rep()
+
+    cluster_manager.print_replication(rep, json_output=False)
+
+    combined = "\n".join(output_lines)
+    assert "test-uuid-1234" in combined
+    assert "COPY" in combined
+    assert "Movies" in combined
+    assert "shard1" in combined
+    assert "node0" in combined
+    assert "node1" in combined
+    assert "READY" in combined
+
+
+def test_print_replication_text_no_errors(
+    cluster_manager: ClusterManager, output_lines: list
+) -> None:
+    """print_replication does not print an Errors section when errors is empty."""
+    rep = _make_rep(errors=[])
+
+    cluster_manager.print_replication(rep, json_output=False)
+
+    combined = "\n".join(output_lines)
+    assert "Errors:" not in combined
+    assert "Last Error:" not in combined
+
+
+def test_print_replication_text_with_errors(
+    cluster_manager: ClusterManager, output_lines: list
+) -> None:
+    """print_replication prints the Errors section and last-error line when errors exist."""
+    rep = _make_rep(errors=["disk full", "timeout"])
+
+    cluster_manager.print_replication(rep, json_output=False)
+
+    combined = "\n".join(output_lines)
+    assert "Last Error:" in combined
+    assert "disk full" in combined
+    assert "Errors:" in combined
+    assert "timeout" in combined
+
+
+def test_print_replication_text_with_status_history(
+    cluster_manager: ClusterManager, output_lines: list
+) -> None:
+    """print_replication prints Status History when status_history is not None."""
+    history_entry = MagicMock()
+    history_entry.state.value = "INDEXING"
+    history_entry.errors = []
+
+    rep = _make_rep(status_history=[history_entry])
+
+    cluster_manager.print_replication(rep, json_output=False)
+
+    combined = "\n".join(output_lines)
+    assert "Status History:" in combined
+    assert "INDEXING" in combined
+
+
+def test_print_replication_text_no_status_history(
+    cluster_manager: ClusterManager, output_lines: list
+) -> None:
+    """print_replication does not print Status History when status_history is None."""
+    rep = _make_rep(status_history=None)
+
+    cluster_manager.print_replication(rep, json_output=False)
+
+    combined = "\n".join(output_lines)
+    assert "Status History:" not in combined
+
+
+# ---------------------------------------------------------------------------
+# print_replication — json output
+# ---------------------------------------------------------------------------
+
+
+def test_print_replication_json_output(capsys) -> None:
+    """print_replication with json_output=True emits valid JSON with expected fields."""
+    mock_client = MagicMock()
+    manager = ClusterManager(mock_client)
+    rep = _make_rep()
+
+    manager.print_replication(rep, json_output=True)
+
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+
+    assert data["uuid"] == "test-uuid-1234"
+    assert data["type"] == "COPY"
+    assert data["collection"] == "Movies"
+    assert data["shard"] == "shard1"
+    assert data["source_node"] == "node0"
+    assert data["target_node"] == "node1"
+    assert data["status"] == "READY"
+    assert data["errors"] == []
+    assert "status_history" not in data
+
+
+def test_print_replication_json_output_with_status_history(capsys) -> None:
+    """print_replication JSON includes status_history when it is not None."""
+    mock_client = MagicMock()
+    manager = ClusterManager(mock_client)
+
+    history_entry = MagicMock()
+    history_entry.state.value = "INDEXING"
+    history_entry.errors = []
+
+    rep = _make_rep(status_history=[history_entry])
+
+    manager.print_replication(rep, json_output=True)
+
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+
+    assert "status_history" in data
+    assert len(data["status_history"]) == 1
+    assert data["status_history"][0]["state"] == "INDEXING"
+    assert data["status_history"][0]["errors"] == []
+
+
+def test_print_replication_json_output_with_errors(capsys) -> None:
+    """print_replication JSON includes errors list when errors are present."""
+    mock_client = MagicMock()
+    manager = ClusterManager(mock_client)
+    rep = _make_rep(errors=["write failed"])
+
+    manager.print_replication(rep, json_output=True)
+
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+
+    assert data["errors"] == ["write failed"]
+
+
+# ---------------------------------------------------------------------------
+# print_replications — text output
+# ---------------------------------------------------------------------------
+
+
+def test_print_replications_text_non_empty(
+    cluster_manager: ClusterManager, output_lines: list
+) -> None:
+    """print_replications renders a table containing all replication data."""
+    rep1 = _make_rep(uuid="uuid-1111", collection="Movies", shard="shard1")
+    rep2 = _make_rep(
+        uuid="uuid-2222",
+        collection="Books",
+        shard="shard2",
+        state_value="INDEXING",
+        transfer_type_value="MOVE",
+        source_node="node2",
+        target_node="node3",
+    )
+
+    cluster_manager.print_replications([rep1, rep2], json_output=False)
+
+    combined = "\n".join(output_lines)
+    assert "uuid-1111" in combined
+    assert "uuid-2222" in combined
+    assert "Movies" in combined
+    assert "Books" in combined
+    assert "READY" in combined
+    assert "INDEXING" in combined
+
+
+def test_print_replications_text_empty(
+    cluster_manager: ClusterManager, output_lines: list
+) -> None:
+    """print_replications prints a 'no replications' message for an empty list."""
+    cluster_manager.print_replications([], json_output=False)
+
+    combined = "\n".join(output_lines)
+    assert "No replications found." in combined
+
+
+# ---------------------------------------------------------------------------
+# print_replications — json output
+# ---------------------------------------------------------------------------
+
+
+def test_print_replications_json_non_empty(capsys) -> None:
+    """print_replications emits valid JSON with a 'replications' array."""
+    mock_client = MagicMock()
+    manager = ClusterManager(mock_client)
+
+    rep1 = _make_rep(uuid="uuid-1111", collection="Movies", shard="shard1")
+    rep2 = _make_rep(
+        uuid="uuid-2222",
+        collection="Books",
+        shard="shard2",
+        state_value="INDEXING",
+        transfer_type_value="MOVE",
+        source_node="node2",
+        target_node="node3",
+    )
+
+    manager.print_replications([rep1, rep2], json_output=True)
+
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+
+    assert "replications" in data
+    assert len(data["replications"]) == 2
+
+    uuids = {r["uuid"] for r in data["replications"]}
+    assert "uuid-1111" in uuids
+    assert "uuid-2222" in uuids
+
+    movies_rep = next(r for r in data["replications"] if r["collection"] == "Movies")
+    assert movies_rep["status"] == "READY"
+    assert movies_rep["shard"] == "shard1"
+    assert movies_rep["source_node"] == "node0"
+    assert movies_rep["target_node"] == "node1"
+    assert movies_rep["type"] == "COPY"
+
+    books_rep = next(r for r in data["replications"] if r["collection"] == "Books")
+    assert books_rep["status"] == "INDEXING"
+    assert books_rep["type"] == "MOVE"
+
+
+def test_print_replications_json_empty(capsys) -> None:
+    """print_replications emits {'replications': []} JSON for an empty list."""
+    mock_client = MagicMock()
+    manager = ClusterManager(mock_client)
+
+    manager.print_replications([], json_output=True)
+
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+
+    assert data == {"replications": []}

--- a/test/unittests/test_managers/test_role_manager.py
+++ b/test/unittests/test_managers/test_role_manager.py
@@ -1,0 +1,206 @@
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+from weaviate_cli.managers.role_manager import RoleManager
+
+
+@pytest.fixture
+def mock_client():
+    client = MagicMock()
+    return client
+
+
+@pytest.fixture
+def role_manager(mock_client):
+    return RoleManager(mock_client)
+
+
+# ---------------------------------------------------------------------------
+# create_role
+# ---------------------------------------------------------------------------
+
+
+def test_create_role_success_text(role_manager, mock_client, capsys):
+    mock_client.roles.create.return_value = None
+
+    with patch("weaviate_cli.managers.role_manager.parse_permission") as mock_parse:
+        mock_parse.return_value = MagicMock()
+        role_manager.create_role(
+            role_name="test-role",
+            permissions=("read_collections:Movies",),
+            json_output=False,
+        )
+
+    out = capsys.readouterr().out
+    assert "test-role" in out
+    assert "created successfully" in out
+
+
+def test_create_role_success_json(role_manager, mock_client, capsys):
+    mock_client.roles.create.return_value = None
+
+    with patch("weaviate_cli.managers.role_manager.parse_permission") as mock_parse:
+        mock_parse.return_value = MagicMock()
+        role_manager.create_role(
+            role_name="test-role",
+            permissions=("read_collections:Movies",),
+            json_output=True,
+        )
+
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["status"] == "success"
+    assert "test-role" in data["message"]
+
+
+def test_create_role_error(role_manager, mock_client):
+    mock_client.roles.create.side_effect = Exception("connection failed")
+
+    with patch("weaviate_cli.managers.role_manager.parse_permission") as mock_parse:
+        mock_parse.return_value = MagicMock()
+        with pytest.raises(Exception) as exc_info:
+            role_manager.create_role(
+                role_name="test-role",
+                permissions=("read_collections:Movies",),
+            )
+
+    assert "Error creating role 'test-role'" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# delete_role
+# ---------------------------------------------------------------------------
+
+
+def test_delete_role_success_text(role_manager, mock_client, capsys):
+    mock_client.roles.exists.side_effect = [True, False]
+
+    role_manager.delete_role(role_name="test-role", json_output=False)
+
+    out = capsys.readouterr().out
+    assert "test-role" in out
+    assert "deleted successfully" in out
+
+
+def test_delete_role_success_json(role_manager, mock_client, capsys):
+    mock_client.roles.exists.side_effect = [True, False]
+
+    role_manager.delete_role(role_name="test-role", json_output=True)
+
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["status"] == "success"
+    assert "test-role" in data["message"]
+
+
+def test_delete_role_not_found(role_manager, mock_client):
+    mock_client.roles.exists.return_value = False
+
+    with pytest.raises(Exception) as exc_info:
+        role_manager.delete_role(role_name="nonexistent-role")
+
+    assert "does not exist" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# add_permission
+# ---------------------------------------------------------------------------
+
+
+def test_add_permission_success_text(role_manager, mock_client, capsys):
+    mock_client.roles.add_permissions.return_value = None
+
+    with patch("weaviate_cli.managers.role_manager.parse_permission") as mock_parse:
+        mock_parse.return_value = MagicMock()
+        role_manager.add_permission(
+            permission=("read_collections:Movies",),
+            role_name="test-role",
+            json_output=False,
+        )
+
+    out = capsys.readouterr().out
+    assert "test-role" in out
+    assert "added" in out
+
+
+def test_add_permission_success_json(role_manager, mock_client, capsys):
+    mock_client.roles.add_permissions.return_value = None
+
+    with patch("weaviate_cli.managers.role_manager.parse_permission") as mock_parse:
+        mock_parse.return_value = MagicMock()
+        role_manager.add_permission(
+            permission=("read_collections:Movies",),
+            role_name="test-role",
+            json_output=True,
+        )
+
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["status"] == "success"
+    assert "test-role" in data["message"]
+
+
+def test_add_permission_error(role_manager, mock_client):
+    mock_client.roles.add_permissions.side_effect = Exception("failed")
+
+    with patch("weaviate_cli.managers.role_manager.parse_permission") as mock_parse:
+        mock_parse.return_value = MagicMock()
+        with pytest.raises(Exception) as exc_info:
+            role_manager.add_permission(
+                permission=("read_collections:Movies",),
+                role_name="test-role",
+            )
+
+    assert "Error adding permission" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# revoke_permission
+# ---------------------------------------------------------------------------
+
+
+def test_revoke_permission_success_text(role_manager, mock_client, capsys):
+    mock_client.roles.remove_permissions.return_value = None
+
+    with patch("weaviate_cli.managers.role_manager.parse_permission") as mock_parse:
+        mock_parse.return_value = MagicMock()
+        role_manager.revoke_permission(
+            permission=("read_collections:Movies",),
+            role_name="test-role",
+            json_output=False,
+        )
+
+    out = capsys.readouterr().out
+    assert "test-role" in out
+    assert "revoked" in out
+
+
+def test_revoke_permission_success_json(role_manager, mock_client, capsys):
+    mock_client.roles.remove_permissions.return_value = None
+
+    with patch("weaviate_cli.managers.role_manager.parse_permission") as mock_parse:
+        mock_parse.return_value = MagicMock()
+        role_manager.revoke_permission(
+            permission=("read_collections:Movies",),
+            role_name="test-role",
+            json_output=True,
+        )
+
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["status"] == "success"
+    assert "test-role" in data["message"]
+
+
+def test_revoke_permission_error(role_manager, mock_client):
+    mock_client.roles.remove_permissions.side_effect = Exception("failed")
+
+    with patch("weaviate_cli.managers.role_manager.parse_permission") as mock_parse:
+        mock_parse.return_value = MagicMock()
+        with pytest.raises(Exception) as exc_info:
+            role_manager.revoke_permission(
+                permission=("read_collections:Movies",),
+                role_name="test-role",
+            )
+
+    assert "Error revoking permission" in str(exc_info.value)

--- a/test/unittests/test_managers/test_tenant_manager.py
+++ b/test/unittests/test_managers/test_tenant_manager.py
@@ -1,0 +1,837 @@
+import json
+import pytest
+from unittest.mock import MagicMock
+
+from weaviate.collections.classes.tenants import TenantActivityStatus
+
+from weaviate_cli.managers.tenant_manager import TenantManager
+from weaviate_cli.defaults import (
+    CreateTenantsDefaults,
+    DeleteTenantsDefaults,
+    GetTenantsDefaults,
+    UpdateTenantsDefaults,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+WEAVIATE_VERSION_GTE_1_25 = "1.26.0"
+WEAVIATE_VERSION_LT_1_25 = "1.24.0"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    """
+    Return a plain MagicMock for the Weaviate client.
+
+    We intentionally do NOT use spec=weaviate.WeaviateClient here because
+    the spec only exposes a handful of top-level methods and does not expose
+    `collections` (which is a property on the real object). Using a plain
+    MagicMock lets us configure .collections.* freely, matching how
+    TenantManager actually uses the client.
+    """
+    return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tenant(activity_status: TenantActivityStatus) -> MagicMock:
+    """Return a mock tenant object with the given activity_status."""
+    t = MagicMock()
+    t.activity_status = activity_status
+    return t
+
+
+def _make_manager_and_collection(
+    mock_client: MagicMock,
+    *,
+    collection_exists: bool = True,
+    mt_enabled: bool = True,
+    version: str = WEAVIATE_VERSION_GTE_1_25,
+    collection_name: str = "TestCollection",
+) -> tuple[TenantManager, MagicMock]:
+    """
+    Wire up mock_client and return (TenantManager, mock_collection).
+
+    The caller can further configure mock_collection.tenants.* to suit each
+    test scenario.
+    """
+    mock_client.collections.exists.return_value = collection_exists
+    mock_client.get_meta.return_value = {"version": version}
+
+    mock_collection = MagicMock()
+    mock_collection.name = collection_name
+    mock_collection.config.get.return_value = MagicMock(
+        multi_tenancy_config=MagicMock(enabled=mt_enabled)
+    )
+    mock_client.collections.get.return_value = mock_collection
+
+    return TenantManager(mock_client), mock_collection
+
+
+# ---------------------------------------------------------------------------
+# create_tenants
+# ---------------------------------------------------------------------------
+
+
+class TestCreateTenants:
+    def test_raises_when_collection_does_not_exist(
+        self, mock_client: MagicMock
+    ) -> None:
+        """create_tenants raises when the target collection is missing."""
+        manager, _ = _make_manager_and_collection(mock_client, collection_exists=False)
+
+        with pytest.raises(Exception, match="does not exist"):
+            manager.create_tenants(collection="Missing")
+
+    def test_raises_when_multi_tenancy_not_enabled(
+        self, mock_client: MagicMock
+    ) -> None:
+        """create_tenants raises when MT is disabled on the collection."""
+        manager, _ = _make_manager_and_collection(mock_client, mt_enabled=False)
+
+        with pytest.raises(Exception, match="does not have multi-tenancy enabled"):
+            manager.create_tenants(collection="TestCollection")
+
+    def test_happy_path_creates_n_tenants_from_zero_text_output(
+        self, mock_client: MagicMock, capsys
+    ) -> None:
+        """
+        With no existing tenants, creates N tenants named Tenant-0 … Tenant-N-1
+        and emits the text success message.
+        """
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        # No existing tenants
+        mock_collection.tenants.get.return_value = {}
+
+        tenant_suffix = "Tenant"
+        number_tenants = 3
+        expected_names = [f"{tenant_suffix}-{i}" for i in range(number_tenants)]
+
+        # get_by_names returns a dict with the right statuses
+        created = {
+            name: _make_tenant(TenantActivityStatus.ACTIVE) for name in expected_names
+        }
+        mock_collection.tenants.get_by_names.return_value = created
+
+        manager.create_tenants(
+            collection="TestCollection",
+            tenant_suffix=tenant_suffix,
+            number_tenants=number_tenants,
+            state="active",
+            json_output=False,
+        )
+
+        out = capsys.readouterr().out
+        assert str(number_tenants) in out
+        assert "tenants added" in out
+
+    def test_happy_path_creates_n_tenants_from_zero_json_output(
+        self, mock_client: MagicMock, capsys
+    ) -> None:
+        """create_tenants emits valid JSON with json_output=True."""
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        mock_collection.tenants.get.return_value = {}
+
+        number_tenants = 2
+        tenant_suffix = "Tenant"
+        expected_names = [f"{tenant_suffix}-{i}" for i in range(number_tenants)]
+        created = {
+            name: _make_tenant(TenantActivityStatus.ACTIVE) for name in expected_names
+        }
+        mock_collection.tenants.get_by_names.return_value = created
+
+        manager.create_tenants(
+            collection="TestCollection",
+            tenant_suffix=tenant_suffix,
+            number_tenants=number_tenants,
+            state="active",
+            json_output=True,
+        )
+
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["status"] == "success"
+        assert data["tenants_created"] == number_tenants
+        assert str(number_tenants) in data["message"]
+
+    def test_continues_numbering_from_highest_plus_one(
+        self, mock_client: MagicMock, capsys
+    ) -> None:
+        """
+        When existing tenants are present that follow the pattern, new tenants
+        continue numbering from highest_index + 1.
+        """
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        # Existing tenants: Tenant-0 and Tenant-1 (highest index = 1)
+        existing = {
+            "Tenant-0": _make_tenant(TenantActivityStatus.ACTIVE),
+            "Tenant-1": _make_tenant(TenantActivityStatus.ACTIVE),
+        }
+        mock_collection.tenants.get.return_value = existing
+
+        number_new = 2
+        # Expected new names start from index 2
+        expected_new_names = ["Tenant-2", "Tenant-3"]
+        created = {
+            name: _make_tenant(TenantActivityStatus.ACTIVE)
+            for name in expected_new_names
+        }
+        mock_collection.tenants.get_by_names.return_value = created
+
+        manager.create_tenants(
+            collection="TestCollection",
+            tenant_suffix="Tenant",
+            number_tenants=number_new,
+            state="active",
+            json_output=False,
+        )
+
+        # Verify get_by_names was called with the new names only
+        mock_collection.tenants.get_by_names.assert_called_once_with(expected_new_names)
+        out = capsys.readouterr().out
+        assert str(number_new) in out
+
+    def test_raises_when_existing_tenant_does_not_match_suffix_pattern(
+        self, mock_client: MagicMock
+    ) -> None:
+        """
+        When an existing tenant name starts with the suffix but the index part
+        is not a valid integer, create_tenants raises.
+        """
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        # Existing tenant whose index portion is non-numeric
+        mock_collection.tenants.get.return_value = {
+            "Tenant-abc": _make_tenant(TenantActivityStatus.ACTIVE),
+        }
+
+        with pytest.raises(Exception, match="does not follow the expected pattern"):
+            manager.create_tenants(
+                collection="TestCollection",
+                tenant_suffix="Tenant",
+                number_tenants=1,
+                state="active",
+            )
+
+    def test_raises_when_existing_tenant_uses_different_suffix(
+        self, mock_client: MagicMock
+    ) -> None:
+        """
+        When an existing tenant does not start with the provided suffix,
+        create_tenants raises.
+        """
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        mock_collection.tenants.get.return_value = {
+            "OtherSuffix-0": _make_tenant(TenantActivityStatus.ACTIVE),
+        }
+
+        with pytest.raises(Exception, match="does not use the provided tenant_suffix"):
+            manager.create_tenants(
+                collection="TestCollection",
+                tenant_suffix="Tenant",
+                number_tenants=1,
+                state="active",
+            )
+
+    def test_uses_batching_when_tenant_batch_size_provided(
+        self, mock_client: MagicMock, capsys
+    ) -> None:
+        """When tenant_batch_size is given, tenants.create is called in batches."""
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        mock_collection.tenants.get.return_value = {}
+
+        number_tenants = 5
+        batch_size = 2
+        expected_names = [f"Tenant-{i}" for i in range(number_tenants)]
+        created = {
+            name: _make_tenant(TenantActivityStatus.ACTIVE) for name in expected_names
+        }
+        mock_collection.tenants.get_by_names.return_value = created
+
+        manager.create_tenants(
+            collection="TestCollection",
+            tenant_suffix="Tenant",
+            number_tenants=number_tenants,
+            tenant_batch_size=batch_size,
+            state="active",
+            json_output=False,
+        )
+
+        # 5 tenants with batch_size=2 → 3 calls: [0,1], [2,3], [4]
+        assert mock_collection.tenants.create.call_count == 3
+
+    def test_raises_when_not_all_tenants_were_created(
+        self, mock_client: MagicMock
+    ) -> None:
+        """
+        If get_by_names returns fewer tenants than requested,
+        create_tenants raises a descriptive error.
+        """
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        mock_collection.tenants.get.return_value = {}
+        # Only 1 of 2 tenants came back from the server
+        mock_collection.tenants.get_by_names.return_value = {
+            "Tenant-0": _make_tenant(TenantActivityStatus.ACTIVE),
+        }
+
+        with pytest.raises(Exception, match="Not all requested tenants were created"):
+            manager.create_tenants(
+                collection="TestCollection",
+                tenant_suffix="Tenant",
+                number_tenants=2,
+                state="active",
+            )
+
+    def test_uses_get_fallback_for_version_lt_1_25(
+        self, mock_client: MagicMock, capsys
+    ) -> None:
+        """
+        For Weaviate < 1.25.0, verification falls back to tenants.get() instead
+        of tenants.get_by_names().
+        """
+        manager, mock_collection = _make_manager_and_collection(
+            mock_client, version=WEAVIATE_VERSION_LT_1_25
+        )
+
+        expected_names = ["Tenant-0", "Tenant-1"]
+        all_tenants = {
+            name: _make_tenant(TenantActivityStatus.ACTIVE) for name in expected_names
+        }
+        # First call (existing check) returns empty; second call (verify) returns all
+        mock_collection.tenants.get.side_effect = [{}, all_tenants]
+
+        manager.create_tenants(
+            collection="TestCollection",
+            tenant_suffix="Tenant",
+            number_tenants=2,
+            state="active",
+            json_output=False,
+        )
+
+        # get_by_names must NOT have been called for old versions
+        mock_collection.tenants.get_by_names.assert_not_called()
+        out = capsys.readouterr().out
+        assert "2" in out
+
+
+# ---------------------------------------------------------------------------
+# delete_tenants
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteTenants:
+    def test_raises_when_collection_does_not_exist(
+        self, mock_client: MagicMock
+    ) -> None:
+        """delete_tenants raises when the target collection is missing."""
+        manager, _ = _make_manager_and_collection(mock_client, collection_exists=False)
+
+        with pytest.raises(Exception, match="does not exist"):
+            manager.delete_tenants(collection="Missing")
+
+    def test_raises_when_multi_tenancy_not_enabled(
+        self, mock_client: MagicMock
+    ) -> None:
+        """delete_tenants raises when MT is disabled."""
+        manager, _ = _make_manager_and_collection(mock_client, mt_enabled=False)
+
+        with pytest.raises(Exception, match="does not have multi-tenancy enabled"):
+            manager.delete_tenants(collection="TestCollection")
+
+    def test_raises_when_no_tenants_present(self, mock_client: MagicMock) -> None:
+        """delete_tenants raises when the collection has no tenants."""
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        mock_collection.tenants.get.return_value = {}
+
+        with pytest.raises(Exception, match="No tenants present"):
+            manager.delete_tenants(
+                collection="TestCollection",
+                tenant_suffix="Tenant",
+                number_tenants=1,
+            )
+
+    def test_happy_path_deletes_tenants_text_output(
+        self, mock_client: MagicMock, capsys
+    ) -> None:
+        """delete_tenants deletes the requested number and prints text output."""
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        tenant_name = "Tenant-0"
+        mock_tenant = _make_tenant(TenantActivityStatus.ACTIVE)
+
+        # First call: list tenants to decide what to delete
+        # Second call: verify remaining count after deletion
+        mock_collection.tenants.get.side_effect = [
+            {tenant_name: mock_tenant},  # initial listing
+            {},  # after deletion (0 remaining)
+        ]
+
+        manager.delete_tenants(
+            collection="TestCollection",
+            tenant_suffix="Tenant",
+            number_tenants=1,
+            json_output=False,
+        )
+
+        mock_collection.tenants.remove.assert_called_once_with(mock_tenant)
+        out = capsys.readouterr().out
+        assert "1" in out
+        assert "deleted" in out
+
+    def test_happy_path_deletes_tenants_json_output(
+        self, mock_client: MagicMock, capsys
+    ) -> None:
+        """delete_tenants emits valid JSON with json_output=True."""
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        mock_tenant = _make_tenant(TenantActivityStatus.ACTIVE)
+        mock_collection.tenants.get.side_effect = [
+            {"Tenant-0": mock_tenant},
+            {},
+        ]
+
+        manager.delete_tenants(
+            collection="TestCollection",
+            tenant_suffix="Tenant",
+            number_tenants=1,
+            json_output=True,
+        )
+
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["status"] == "success"
+        assert data["tenants_deleted"] == 1
+        assert "deleted" in data["message"]
+
+    def test_deletes_only_up_to_number_tenants(
+        self, mock_client: MagicMock, capsys
+    ) -> None:
+        """
+        When there are more tenants than number_tenants, only the first
+        number_tenants are deleted.
+        """
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        tenants = {
+            f"Tenant-{i}": _make_tenant(TenantActivityStatus.ACTIVE) for i in range(5)
+        }
+        mock_collection.tenants.get.side_effect = [
+            tenants,  # initial listing
+            dict(list(tenants.items())[2:]),  # 3 remaining after deleting 2
+        ]
+
+        manager.delete_tenants(
+            collection="TestCollection",
+            tenant_suffix="Tenant",
+            number_tenants=2,
+            json_output=False,
+        )
+
+        assert mock_collection.tenants.remove.call_count == 2
+
+    def test_deletes_using_tenants_list(self, mock_client: MagicMock, capsys) -> None:
+        """When tenants_list is provided, get_by_names is used."""
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        specific_tenant = _make_tenant(TenantActivityStatus.ACTIVE)
+        # tenants.get() is called for the suffix-filter even when tenants_list given
+        mock_collection.tenants.get.side_effect = [
+            {"Tenant-5": specific_tenant},  # suffix-filter listing
+            {},  # post-delete verification
+        ]
+        mock_collection.tenants.get_by_names.return_value = {
+            "Tenant-5": specific_tenant
+        }
+
+        manager.delete_tenants(
+            collection="TestCollection",
+            tenant_suffix="Tenant",
+            tenants_list=["Tenant-5"],
+            number_tenants=1,
+            json_output=False,
+        )
+
+        mock_collection.tenants.get_by_names.assert_called_once_with(["Tenant-5"])
+        mock_collection.tenants.remove.assert_called_once_with(specific_tenant)
+
+    def test_delete_all_with_wildcard_suffix(
+        self, mock_client: MagicMock, capsys
+    ) -> None:
+        """When tenant_suffix='*', all tenants in the collection are deleted."""
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        tenants = {
+            "Alpha-0": _make_tenant(TenantActivityStatus.ACTIVE),
+            "Beta-0": _make_tenant(TenantActivityStatus.INACTIVE),
+        }
+        mock_collection.tenants.get.side_effect = [
+            tenants,  # initial listing (wildcard uses all)
+            {},  # post-delete verification
+        ]
+
+        manager.delete_tenants(
+            collection="TestCollection",
+            tenant_suffix="*",
+            number_tenants=2,
+            json_output=False,
+        )
+
+        assert mock_collection.tenants.remove.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# get_tenants
+# ---------------------------------------------------------------------------
+
+
+class TestGetTenants:
+    def test_happy_path_all_tenants_json_output(
+        self, mock_client: MagicMock, capsys
+    ) -> None:
+        """get_tenants returns all tenants and emits valid JSON."""
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        active_tenant = _make_tenant(TenantActivityStatus.ACTIVE)
+        inactive_tenant = _make_tenant(TenantActivityStatus.INACTIVE)
+
+        tenants = {
+            "Tenant-0": active_tenant,
+            "Tenant-1": inactive_tenant,
+        }
+        mock_collection.tenants.get.return_value = tenants
+
+        result = manager.get_tenants(
+            collection="TestCollection",
+            tenant_id=None,
+            verbose=False,
+            json_output=True,
+        )
+
+        assert result == tenants
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["summary"]["total"] == 2
+        assert data["summary"]["active"] == 1
+        assert data["summary"]["inactive"] == 1
+        assert len(data["tenants"]) == 2
+
+    def test_happy_path_all_tenants_verbose_text_output(
+        self, mock_client: MagicMock, capsys
+    ) -> None:
+        """get_tenants with verbose=True prints per-tenant rows."""
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        t = _make_tenant(TenantActivityStatus.ACTIVE)
+        mock_collection.tenants.get.return_value = {"Tenant-0": t}
+
+        manager.get_tenants(
+            collection="TestCollection",
+            tenant_id=None,
+            verbose=True,
+            json_output=False,
+        )
+
+        out = capsys.readouterr().out
+        assert "Tenant-0" in out
+        assert "ACTIVE" in out
+
+    def test_happy_path_all_tenants_summary_text_output(
+        self, mock_client: MagicMock, capsys
+    ) -> None:
+        """get_tenants with verbose=False prints the summary row."""
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        active_tenant = _make_tenant(TenantActivityStatus.ACTIVE)
+        inactive_tenant = _make_tenant(TenantActivityStatus.INACTIVE)
+        offloaded_tenant = _make_tenant(TenantActivityStatus.OFFLOADED)
+        mock_collection.tenants.get.return_value = {
+            "Tenant-0": active_tenant,
+            "Tenant-1": inactive_tenant,
+            "Tenant-2": offloaded_tenant,
+        }
+
+        manager.get_tenants(
+            collection="TestCollection",
+            tenant_id=None,
+            verbose=False,
+            json_output=False,
+        )
+
+        out = capsys.readouterr().out
+        # Summary header and data row should both be present
+        assert "Number Tenants" in out
+        assert "3" in out
+
+    def test_with_tenant_id_found(self, mock_client: MagicMock, capsys) -> None:
+        """get_tenants returns the single tenant when tenant_id is given and found."""
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        t = _make_tenant(TenantActivityStatus.ACTIVE)
+        mock_collection.tenants.get_by_names.return_value = {"Tenant-5": t}
+
+        result = manager.get_tenants(
+            collection="TestCollection",
+            tenant_id="Tenant-5",
+            verbose=True,
+            json_output=False,
+        )
+
+        mock_collection.tenants.get_by_names.assert_called_once_with(["Tenant-5"])
+        assert "Tenant-5" in result
+
+    def test_with_tenant_id_not_found_raises(self, mock_client: MagicMock) -> None:
+        """get_tenants raises when tenant_id is given but not found."""
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        mock_collection.tenants.get_by_names.return_value = {}
+
+        with pytest.raises(Exception, match="not found"):
+            manager.get_tenants(
+                collection="TestCollection",
+                tenant_id="NonExistentTenant",
+                verbose=False,
+                json_output=False,
+            )
+
+    def test_returns_tenant_dict(self, mock_client: MagicMock, capsys) -> None:
+        """get_tenants always returns the dict of tenants."""
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        tenants = {"Tenant-0": _make_tenant(TenantActivityStatus.ACTIVE)}
+        mock_collection.tenants.get.return_value = tenants
+
+        result = manager.get_tenants(
+            collection="TestCollection",
+            json_output=False,
+        )
+
+        assert result is tenants
+
+
+# ---------------------------------------------------------------------------
+# update_tenants
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateTenants:
+    def test_raises_when_collection_does_not_exist(
+        self, mock_client: MagicMock
+    ) -> None:
+        """update_tenants raises when the target collection is missing."""
+        manager, _ = _make_manager_and_collection(mock_client, collection_exists=False)
+
+        with pytest.raises(Exception, match="does not exist"):
+            manager.update_tenants(collection="Missing")
+
+    def test_raises_when_multi_tenancy_not_enabled(
+        self, mock_client: MagicMock
+    ) -> None:
+        """update_tenants raises when MT is disabled."""
+        manager, _ = _make_manager_and_collection(mock_client, mt_enabled=False)
+
+        with pytest.raises(Exception, match="does not have multi-tenancy enabled"):
+            manager.update_tenants(collection="TestCollection")
+
+    def test_raises_when_not_enough_tenants_with_suffix(
+        self, mock_client: MagicMock
+    ) -> None:
+        """
+        update_tenants raises when fewer tenants than number_tenants have the
+        requested suffix.
+        """
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        # Only 1 tenant with the suffix but we request 5
+        mock_collection.tenants.get.return_value = {
+            "Tenant-0": _make_tenant(TenantActivityStatus.INACTIVE),
+        }
+
+        with pytest.raises(Exception, match="Not enough tenants present"):
+            manager.update_tenants(
+                collection="TestCollection",
+                tenant_suffix="Tenant",
+                number_tenants=5,
+                state="active",
+            )
+
+    def test_happy_path_updates_state_json_output(
+        self, mock_client: MagicMock, capsys
+    ) -> None:
+        """update_tenants updates tenant state and emits valid JSON."""
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        inactive_tenant = _make_tenant(TenantActivityStatus.INACTIVE)
+        inactive_tenant.name = "Tenant-0"
+
+        # tenants.get() used for suffix-filter
+        mock_collection.tenants.get.return_value = {
+            "Tenant-0": inactive_tenant,
+        }
+
+        # After update, get_by_names returns the tenant with ACTIVE status
+        updated_tenant = _make_tenant(TenantActivityStatus.ACTIVE)
+        updated_tenant.name = "Tenant-0"
+        mock_collection.tenants.get_by_names.return_value = {
+            "Tenant-0": updated_tenant,
+        }
+
+        manager.update_tenants(
+            collection="TestCollection",
+            tenant_suffix="Tenant",
+            number_tenants=1,
+            state="active",
+            tenants=None,
+            json_output=True,
+        )
+
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["status"] == "success"
+        assert data["tenants_updated"] == 1
+
+    def test_happy_path_updates_state_text_output(
+        self, mock_client: MagicMock, capsys
+    ) -> None:
+        """update_tenants emits text output when json_output=False."""
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        inactive_tenant = _make_tenant(TenantActivityStatus.INACTIVE)
+        inactive_tenant.name = "Tenant-0"
+
+        mock_collection.tenants.get.return_value = {
+            "Tenant-0": inactive_tenant,
+        }
+
+        updated_tenant = _make_tenant(TenantActivityStatus.ACTIVE)
+        updated_tenant.name = "Tenant-0"
+        mock_collection.tenants.get_by_names.return_value = {
+            "Tenant-0": updated_tenant,
+        }
+
+        manager.update_tenants(
+            collection="TestCollection",
+            tenant_suffix="Tenant",
+            number_tenants=1,
+            state="active",
+            tenants=None,
+            json_output=False,
+        )
+
+        out = capsys.readouterr().out
+        assert "1" in out
+        assert "updated" in out
+
+    def test_update_via_tenants_argument(self, mock_client: MagicMock, capsys) -> None:
+        """
+        When the tenants argument (comma-separated string) is given,
+        get_by_names is used to fetch those specific tenants.
+        """
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        cold_tenant = _make_tenant(TenantActivityStatus.INACTIVE)
+        cold_tenant.name = "Tenant-3"
+
+        mock_collection.tenants.get_by_names.side_effect = [
+            {"Tenant-3": cold_tenant},  # fetch for update
+            {"Tenant-3": cold_tenant},  # post-update verification
+        ]
+
+        manager.update_tenants(
+            collection="TestCollection",
+            tenant_suffix="Tenant",
+            number_tenants=1,
+            state="cold",
+            tenants="Tenant-3",
+            json_output=False,
+        )
+
+        # tenants.get() should NOT have been called for the suffix-filter path
+        mock_collection.tenants.get.assert_not_called()
+        out = capsys.readouterr().out
+        assert "updated" in out
+
+    def test_uses_get_fallback_for_version_lt_1_25(
+        self, mock_client: MagicMock, capsys
+    ) -> None:
+        """
+        For Weaviate < 1.25.0, verification after update falls back to
+        tenants.get() filtered by name instead of get_by_names().
+        """
+        manager, mock_collection = _make_manager_and_collection(
+            mock_client, version=WEAVIATE_VERSION_LT_1_25
+        )
+
+        existing_tenant = _make_tenant(TenantActivityStatus.INACTIVE)
+        existing_tenant.name = "Tenant-0"
+
+        updated_tenant = _make_tenant(TenantActivityStatus.ACTIVE)
+        updated_tenant.name = "Tenant-0"
+
+        # First call → suffix-filter; second call → post-update verify
+        mock_collection.tenants.get.side_effect = [
+            {"Tenant-0": existing_tenant},
+            {"Tenant-0": updated_tenant},
+        ]
+
+        manager.update_tenants(
+            collection="TestCollection",
+            tenant_suffix="Tenant",
+            number_tenants=1,
+            state="active",
+            tenants=None,
+            json_output=False,
+        )
+
+        # get_by_names must NOT have been called for old versions
+        mock_collection.tenants.get_by_names.assert_not_called()
+        out = capsys.readouterr().out
+        assert "updated" in out
+
+    def test_skips_update_call_when_tenant_already_in_desired_state(
+        self, mock_client: MagicMock, capsys
+    ) -> None:
+        """
+        When a tenant already has the target activity_status, tenants.update
+        is called with the tenant as-is (no new Tenant object).
+        """
+        manager, mock_collection = _make_manager_and_collection(mock_client)
+
+        already_active = _make_tenant(TenantActivityStatus.ACTIVE)
+        already_active.name = "Tenant-0"
+
+        mock_collection.tenants.get.return_value = {
+            "Tenant-0": already_active,
+        }
+        mock_collection.tenants.get_by_names.return_value = {
+            "Tenant-0": already_active,
+        }
+
+        manager.update_tenants(
+            collection="TestCollection",
+            tenant_suffix="Tenant",
+            number_tenants=1,
+            state="active",
+            tenants=None,
+            json_output=False,
+        )
+
+        # The existing tenant object should be passed directly (no new Tenant)
+        mock_collection.tenants.update.assert_called_once_with(already_active)

--- a/test/unittests/test_managers/test_user_manager.py
+++ b/test/unittests/test_managers/test_user_manager.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 from unittest.mock import Mock, patch
 from weaviate_cli.managers.user_manager import UserManager
@@ -323,3 +324,67 @@ def test_print_user(user_manager, capsys):
     # Assert
     captured = capsys.readouterr()
     assert captured.out == f"User: {user}\n"
+
+
+# ---------------------------------------------------------------------------
+# add_role json_output
+# ---------------------------------------------------------------------------
+
+
+def test_add_role_json_output(user_manager, capsys):
+    role_name = ("admin",)
+    user_name = "test_user"
+    user_manager.client.get_meta.return_value = {"version": "1.30.0"}
+
+    user_manager.add_role(role_name, user_name, "db", json_output=True)
+
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["status"] == "success"
+    assert "admin" in data["message"]
+    assert user_name in data["message"]
+
+
+def test_add_role_text_output(user_manager, capsys):
+    role_name = ("admin",)
+    user_name = "test_user"
+    user_manager.client.get_meta.return_value = {"version": "1.30.0"}
+
+    user_manager.add_role(role_name, user_name, "db", json_output=False)
+
+    out = capsys.readouterr().out
+    assert "admin" in out
+    assert user_name in out
+    assert "assigned" in out
+
+
+# ---------------------------------------------------------------------------
+# revoke_role json_output
+# ---------------------------------------------------------------------------
+
+
+def test_revoke_role_json_output(user_manager, capsys):
+    role_name = ("admin",)
+    user_name = "test_user"
+    user_manager.client.get_meta.return_value = {"version": "1.30.0"}
+
+    user_manager.revoke_role(role_name, user_name, "db", json_output=True)
+
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["status"] == "success"
+    assert "admin" in data["message"]
+    assert user_name in data["message"]
+
+
+def test_revoke_role_text_output(user_manager, capsys):
+    role_name = ("admin",)
+    user_name = "test_user"
+    user_manager.client.get_meta.return_value = {"version": "1.30.0"}
+
+    user_manager.revoke_role(role_name, user_name, "db", json_output=False)
+
+    out = capsys.readouterr().out
+    assert "admin" in out
+    assert user_name in out
+    assert "revoked" in out

--- a/weaviate_cli/commands/assign.py
+++ b/weaviate_cli/commands/assign.py
@@ -33,9 +33,16 @@ def assign() -> None:
     default="db",
     help="The type of user to add the role to.",
 )
+@click.option(
+    "--json", "json_output", is_flag=True, default=False, help="Output in JSON format."
+)
 @click.pass_context
 def assign_role_cli(
-    ctx: click.Context, role_name: tuple[str], user_name: str, user_type: str
+    ctx: click.Context,
+    role_name: tuple[str],
+    user_name: str,
+    user_type: str,
+    json_output: bool,
 ) -> None:
     """Assigns a role to a user."""
     client = None
@@ -43,7 +50,10 @@ def assign_role_cli(
         client = get_client_from_context(ctx)
         user_manager = UserManager(client)
         user_manager.add_role(
-            role_name=role_name, user_name=user_name, user_type=user_type
+            role_name=role_name,
+            user_name=user_name,
+            user_type=user_type,
+            json_output=json_output,
         )
     except Exception as e:
         click.echo(f"Error: {e}")
@@ -68,9 +78,12 @@ def assign_role_cli(
     required=True,
     help="The name of the role to add the permission to.",
 )
+@click.option(
+    "--json", "json_output", is_flag=True, default=False, help="Output in JSON format."
+)
 @click.pass_context
 def assign_permission_cli(
-    ctx: click.Context, permission: tuple[str], role_name: str
+    ctx: click.Context, permission: tuple[str], role_name: str, json_output: bool
 ) -> None:
     """Assigns a permission to a role."""
 
@@ -78,7 +91,9 @@ def assign_permission_cli(
     try:
         client = get_client_from_context(ctx)
         role_manager = RoleManager(client)
-        role_manager.add_permission(permission=permission, role_name=role_name)
+        role_manager.add_permission(
+            permission=permission, role_name=role_name, json_output=json_output
+        )
     except Exception as e:
         click.echo(f"Error: {e}")
         if client:

--- a/weaviate_cli/commands/benchmark.py
+++ b/weaviate_cli/commands/benchmark.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import click
 import sys
 from typing import Optional, List
@@ -108,6 +109,9 @@ def benchmark():
     default=CreateBenchmarkDefaults.tenant,
     help="Tenant to use to run the benchmark against. Works only on multitenant collections. Default: None",
 )
+@click.option(
+    "--json", "json_output", is_flag=True, default=False, help="Output in JSON format."
+)
 @click.pass_context
 def benchmark_qps(
     ctx: click.Context,
@@ -128,6 +132,7 @@ def benchmark_qps(
     concurrency: Optional[int],
     file_alias: Optional[str],
     tenant: Optional[str],
+    json_output: bool,
 ) -> None:
     """Run QPS benchmark on the specified collection."""
     async_client = None
@@ -161,6 +166,7 @@ def benchmark_qps(
                 generate_graph=generate_graph,
                 file_alias=file_alias,
                 tenant=tenant,
+                json_output=json_output,
             )
         )
     except Exception as e:

--- a/weaviate_cli/commands/query.py
+++ b/weaviate_cli/commands/query.py
@@ -62,6 +62,13 @@ def query() -> None:
     default=QueryDataDefaults.target_vector,
     help="Target vector to query (default: 'None').",
 )
+@click.option(
+    "--json",
+    "json_output",
+    is_flag=True,
+    default=False,
+    help="Output in JSON format.",
+)
 @click.pass_context
 def query_data_cli(
     ctx,
@@ -73,6 +80,7 @@ def query_data_cli(
     properties,
     tenants,
     target_vector,
+    json_output,
 ):
     """Query data in a collection in Weaviate."""
 
@@ -90,6 +98,7 @@ def query_data_cli(
             properties=properties,
             tenants=tenants,
             target_vector=target_vector,
+            json_output=json_output,
         )
     except Exception as e:
         click.echo(f"Error: {e}")
@@ -125,6 +134,13 @@ def query_data_cli(
     default=False,
     help="Include the history of the replication operations.",
 )
+@click.option(
+    "--json",
+    "json_output",
+    is_flag=True,
+    default=False,
+    help="Output in JSON format.",
+)
 @click.pass_context
 def query_replications_cli(
     ctx: click.Context,
@@ -132,6 +148,7 @@ def query_replications_cli(
     shard: Optional[str],
     target_node: Optional[str],
     history: bool,
+    json_output: bool,
 ) -> None:
     """Query replication operations by collection, collection and shard, or target node in Weaviate."""
 
@@ -159,10 +176,7 @@ def query_replications_cli(
         else:
             ops = manager.query_all_replications(history)
 
-        for op in ops:
-            manager.print_replication(op)
-        if not ops:
-            click.echo("No replication operations found.")
+        manager.print_replications(ops, json_output=json_output)
 
     except WeaviateConnectionError as e:
         click.echo(f"Connection error: {e}")
@@ -184,11 +198,19 @@ def query_replications_cli(
     default=None,
     help="The shard to query. If not provided, the state of all shards will be queried.",
 )
+@click.option(
+    "--json",
+    "json_output",
+    is_flag=True,
+    default=False,
+    help="Output in JSON format.",
+)
 @click.pass_context
 def query_sharding_state_cli(
     ctx: click.Context,
     collection: str,
     shard: Optional[str],
+    json_output: bool,
 ):
     """Query the sharding state of a COLLECTION in Weaviate."""
 
@@ -203,14 +225,15 @@ def query_sharding_state_cli(
             click.echo(f"No sharding state found for collection '{collection}'")
             return
 
-        if shard:
-            click.echo(
-                f"Sharding state for collection '{collection}', shard '{shard}':"
-            )
-        else:
-            click.echo(f"Sharding state for collection '{collection}':")
+        if not json_output:
+            if shard:
+                click.echo(
+                    f"Sharding state for collection '{collection}', shard '{shard}':"
+                )
+            else:
+                click.echo(f"Sharding state for collection '{collection}':")
 
-        manager.print_sharding_state(state)
+        manager.print_sharding_state(state, json_output=json_output)
 
     except WeaviateConnectionError as e:
         click.echo(f"Connection error: {e}")

--- a/weaviate_cli/commands/restore.py
+++ b/weaviate_cli/commands/restore.py
@@ -38,8 +38,11 @@ def restore() -> None:
     default=RestoreBackupDefaults.exclude,
     help="Collection to exclude in backup (default: None).",
 )
+@click.option(
+    "--json", "json_output", is_flag=True, default=False, help="Output in JSON format."
+)
 @click.pass_context
-def restore_backup_cli(ctx, backend, include, exclude, backup_id, wait):
+def restore_backup_cli(ctx, backend, include, exclude, backup_id, wait, json_output):
     """Restore a backup in Weaviate."""
 
     client = None
@@ -52,6 +55,7 @@ def restore_backup_cli(ctx, backend, include, exclude, backup_id, wait):
             include=include,
             exclude=exclude,
             wait=wait,
+            json_output=json_output,
         )
     except Exception as e:
         click.echo(f"Error: {e}")

--- a/weaviate_cli/commands/revoke.py
+++ b/weaviate_cli/commands/revoke.py
@@ -33,9 +33,16 @@ def revoke() -> None:
     default="db",
     help="The type of user to revoke the role from.",
 )
+@click.option(
+    "--json", "json_output", is_flag=True, default=False, help="Output in JSON format."
+)
 @click.pass_context
 def revoke_role_cli(
-    ctx: click.Context, role_name: tuple[str], user_name: str, user_type: str
+    ctx: click.Context,
+    role_name: tuple[str],
+    user_name: str,
+    user_type: str,
+    json_output: bool,
 ) -> None:
     """Revoke a role from a user."""
     client = None
@@ -43,7 +50,10 @@ def revoke_role_cli(
         client = get_client_from_context(ctx)
         user_manager = UserManager(client)
         user_manager.revoke_role(
-            role_name=role_name, user_name=user_name, user_type=user_type
+            role_name=role_name,
+            user_name=user_name,
+            user_type=user_type,
+            json_output=json_output,
         )
     except Exception as e:
         click.echo(f"Error: {e}")
@@ -68,16 +78,21 @@ def revoke_role_cli(
     required=True,
     help="The role to revoke the permission from.",
 )
+@click.option(
+    "--json", "json_output", is_flag=True, default=False, help="Output in JSON format."
+)
 @click.pass_context
 def revoke_permission_cli(
-    ctx: click.Context, permission: tuple[str], role_name: str
+    ctx: click.Context, permission: tuple[str], role_name: str, json_output: bool
 ) -> None:
     """Revoke a permission from a role."""
     client = None
     try:
         client = get_client_from_context(ctx)
         role_manager = RoleManager(client)
-        role_manager.revoke_permission(permission=permission, role_name=role_name)
+        role_manager.revoke_permission(
+            permission=permission, role_name=role_name, json_output=json_output
+        )
     except Exception as e:
         click.echo(f"Error: {e}")
         if client:

--- a/weaviate_cli/commands/update.py
+++ b/weaviate_cli/commands/update.py
@@ -83,6 +83,9 @@ def update() -> None:
     ),
     help="Replication deletion strategy.",
 )
+@click.option(
+    "--json", "json_output", is_flag=True, default=False, help="Output in JSON format."
+)
 @click.pass_context
 def update_collection_cli(
     ctx: click.Context,
@@ -95,6 +98,7 @@ def update_collection_cli(
     auto_tenant_creation: Optional[bool],
     auto_tenant_activation: Optional[bool],
     replication_deletion_strategy: Optional[str],
+    json_output: bool,
 ) -> None:
     """Update a collection in Weaviate."""
 
@@ -113,6 +117,7 @@ def update_collection_cli(
             auto_tenant_creation=auto_tenant_creation,
             auto_tenant_activation=auto_tenant_activation,
             replication_deletion_strategy=replication_deletion_strategy,
+            json_output=json_output,
         )
     except Exception as e:
         click.echo(f"Error: {e}")
@@ -150,8 +155,13 @@ def update_collection_cli(
     default=UpdateTenantsDefaults.tenants,
     help="Comma separated list of tenants to update. Ex: 'Tenant-1,Tenant-2,Tenant-3,Tenant-4'",
 )
+@click.option(
+    "--json", "json_output", is_flag=True, default=False, help="Output in JSON format."
+)
 @click.pass_context
-def update_tenants_cli(ctx, collection, tenant_suffix, number_tenants, state, tenants):
+def update_tenants_cli(
+    ctx, collection, tenant_suffix, number_tenants, state, tenants, json_output
+):
     """Update tenants in Weaviate."""
 
     client = None
@@ -164,6 +174,7 @@ def update_tenants_cli(ctx, collection, tenant_suffix, number_tenants, state, te
             number_tenants=number_tenants,
             state=state,
             tenants=tenants,
+            json_output=json_output,
         )
     except Exception as e:
         click.echo(f"Error: {e}")
@@ -197,6 +208,9 @@ def update_tenants_cli(ctx, collection, tenant_suffix, number_tenants, state, te
     is_flag=True,
     help="Update all collections.",
 )
+@click.option(
+    "--json", "json_output", is_flag=True, default=False, help="Output in JSON format."
+)
 @click.pass_context
 def update_shards_cli(
     ctx: click.Context,
@@ -204,6 +218,7 @@ def update_shards_cli(
     collection: Optional[str],
     shards: Optional[str],
     all: bool,
+    json_output: bool,
 ) -> None:
     """Update shards in Weaviate."""
 
@@ -217,6 +232,7 @@ def update_shards_cli(
             collection=collection,
             shards=shards,
             all=all,
+            json_output=json_output,
         )
     except Exception as e:
         click.echo(f"Error: {e}")
@@ -255,9 +271,19 @@ def update_shards_cli(
     default=UpdateDataDefaults.verbose,
     help="Show detailed progress information (default: True).",
 )
+@click.option(
+    "--json", "json_output", is_flag=True, default=False, help="Output in JSON format."
+)
 @click.pass_context
 def update_data_cli(
-    ctx, collection, limit, consistency_level, randomize, skip_seed, verbose
+    ctx,
+    collection,
+    limit,
+    consistency_level,
+    randomize,
+    skip_seed,
+    verbose,
+    json_output,
 ):
     """Update data in a collection in Weaviate."""
 
@@ -273,6 +299,7 @@ def update_data_cli(
             randomize=randomize,
             skip_seed=skip_seed,
             verbose=verbose,
+            json_output=json_output,
         )
     except Exception as e:
         click.echo(f"Error: {e}")
@@ -313,6 +340,9 @@ def update_data_cli(
     is_flag=True,
     help="Store the rotated API key in the config file. Only works when auth type is 'user' and --rotate_api_key is used.",
 )
+@click.option(
+    "--json", "json_output", is_flag=True, default=False, help="Output in JSON format."
+)
 @click.pass_context
 def update_user_cli(
     ctx: click.Context,
@@ -321,6 +351,7 @@ def update_user_cli(
     activate: bool,
     deactivate: bool,
     store: bool,
+    json_output: bool,
 ) -> None:
     """Update a user in Weaviate."""
 
@@ -365,17 +396,62 @@ def update_user_cli(
             with open(config_path, "w", encoding="utf-8") as f:
                 json.dump(config, f, indent=4)
 
-            click.echo(
-                f"API key for user '{user_name}' has been rotated and stored in config file at {config_path}"
-            )
+            if json_output:
+                click.echo(
+                    json.dumps(
+                        {
+                            "status": "success",
+                            "message": f"API key for user '{user_name}' has been rotated and stored in config file at {config_path}",
+                        },
+                        indent=2,
+                    )
+                )
+            else:
+                click.echo(
+                    f"API key for user '{user_name}' has been rotated and stored in config file at {config_path}"
+                )
         elif rotate_api_key and api_key:
-            click.echo(
-                f"API key for user '{user_name}' rotated successfully: \n{api_key}"
-            )
+            if json_output:
+                click.echo(
+                    json.dumps(
+                        {
+                            "status": "success",
+                            "message": f"API key for user '{user_name}' rotated successfully.",
+                            "api_key": api_key,
+                        },
+                        indent=2,
+                    )
+                )
+            else:
+                click.echo(
+                    f"API key for user '{user_name}' rotated successfully: \n{api_key}"
+                )
         elif activate:
-            click.echo(f"User '{user_name}' activated successfully.")
+            if json_output:
+                click.echo(
+                    json.dumps(
+                        {
+                            "status": "success",
+                            "message": f"User '{user_name}' activated successfully.",
+                        },
+                        indent=2,
+                    )
+                )
+            else:
+                click.echo(f"User '{user_name}' activated successfully.")
         elif deactivate:
-            click.echo(f"User '{user_name}' deactivated successfully.")
+            if json_output:
+                click.echo(
+                    json.dumps(
+                        {
+                            "status": "success",
+                            "message": f"User '{user_name}' deactivated successfully.",
+                        },
+                        indent=2,
+                    )
+                )
+            else:
+                click.echo(f"User '{user_name}' deactivated successfully.")
 
     except Exception as e:
         click.echo(f"Error: {e}")
@@ -390,14 +466,21 @@ def update_user_cli(
 @update.command("alias")
 @click.argument("alias_name")
 @click.argument("collection")
+@click.option(
+    "--json", "json_output", is_flag=True, default=False, help="Output in JSON format."
+)
 @click.pass_context
-def update_alias_cli(ctx: click.Context, alias_name: str, collection: str) -> None:
+def update_alias_cli(
+    ctx: click.Context, alias_name: str, collection: str, json_output: bool
+) -> None:
     """Update an alias for a collection in Weaviate."""
     client = None
     try:
         client = get_client_from_context(ctx)
         alias_man = AliasManager(client)
-        alias_man.update_alias(alias_name=alias_name, collection=collection)
+        alias_man.update_alias(
+            alias_name=alias_name, collection=collection, json_output=json_output
+        )
     except Exception as e:
         click.echo(f"Error: {e}")
         if client:

--- a/weaviate_cli/defaults.py
+++ b/weaviate_cli/defaults.py
@@ -120,7 +120,6 @@ class CreateBenchmarkDefaults:
     fail_on_timeout: bool = False
     max_duration: int = 300
     collection: str = "Movies"
-    term: str = "Action movies"
     certainty: bool = False
     output: str = "stdout"
     query_type: str = "hybrid"

--- a/weaviate_cli/managers/alias_manager.py
+++ b/weaviate_cli/managers/alias_manager.py
@@ -1,3 +1,4 @@
+import json
 from typing import Optional
 import click
 from weaviate.client import WeaviateClient
@@ -8,25 +9,51 @@ class AliasManager:
     def __init__(self, client: WeaviateClient):
         self.client = client
 
-    def create_alias(self, alias_name: str, collection: str) -> None:
+    def create_alias(
+        self, alias_name: str, collection: str, json_output: bool = False
+    ) -> None:
         try:
             self.client.alias.create(
                 alias_name=alias_name, target_collection=collection
             )
-            click.echo(
-                f"Alias '{alias_name}' to collection '{collection}' created successfully."
-            )
+            if json_output:
+                click.echo(
+                    json.dumps(
+                        {
+                            "status": "success",
+                            "message": f"Alias '{alias_name}' to collection '{collection}' created successfully.",
+                        },
+                        indent=2,
+                    )
+                )
+            else:
+                click.echo(
+                    f"Alias '{alias_name}' to collection '{collection}' created successfully."
+                )
         except Exception as e:
             raise Exception(f"Error creating alias '{alias_name}': {e}")
 
-    def update_alias(self, alias_name: str, collection: str) -> None:
+    def update_alias(
+        self, alias_name: str, collection: str, json_output: bool = False
+    ) -> None:
         try:
             self.client.alias.update(
                 alias_name=alias_name, new_target_collection=collection
             )
-            click.echo(
-                f"Alias '{alias_name}' to collection '{collection}' updated successfully."
-            )
+            if json_output:
+                click.echo(
+                    json.dumps(
+                        {
+                            "status": "success",
+                            "message": f"Alias '{alias_name}' to collection '{collection}' updated successfully.",
+                        },
+                        indent=2,
+                    )
+                )
+            else:
+                click.echo(
+                    f"Alias '{alias_name}' to collection '{collection}' updated successfully."
+                )
         except Exception as e:
             raise Exception(f"Error updating alias '{alias_name}': {e}")
 
@@ -36,9 +63,21 @@ class AliasManager:
         except Exception as e:
             raise Exception(f"Error getting alias '{alias_name}': {e}")
 
-    def delete_alias(self, alias_name: str) -> None:
+    def delete_alias(self, alias_name: str, json_output: bool = False) -> None:
         try:
             self.client.alias.delete(alias_name=alias_name)
+            if json_output:
+                click.echo(
+                    json.dumps(
+                        {
+                            "status": "success",
+                            "message": f"Alias '{alias_name}' deleted successfully.",
+                        },
+                        indent=2,
+                    )
+                )
+            else:
+                click.echo(f"Alias '{alias_name}' deleted successfully.")
         except Exception as e:
             raise Exception(f"Error deleting alias '{alias_name}': {e}")
 
@@ -48,5 +87,12 @@ class AliasManager:
         except Exception as e:
             raise Exception(f"Error listing aliases: {e}")
 
-    def print_alias(self, alias: AliasReturn) -> None:
-        click.echo(f"Alias: {alias.alias} -> {alias.collection}")
+    def print_alias(self, alias: AliasReturn, json_output: bool = False) -> None:
+        if json_output:
+            click.echo(
+                json.dumps(
+                    {"alias": alias.alias, "collection": alias.collection}, indent=2
+                )
+            )
+        else:
+            click.echo(f"Alias: {alias.alias} -> {alias.collection}")

--- a/weaviate_cli/managers/benchmark_manager.py
+++ b/weaviate_cli/managers/benchmark_manager.py
@@ -1,5 +1,6 @@
 import asyncio
 import csv
+import json
 from io import TextIOWrapper
 import random
 import time
@@ -427,6 +428,7 @@ class BenchmarkQPSManager(BenchmarkManager):
         fail_on_timeout: bool = CreateBenchmarkDefaults.fail_on_timeout,
         file_alias: Optional[str] = CreateBenchmarkDefaults.file_alias,
         tenant: Optional[str] = CreateBenchmarkDefaults.tenant,
+        json_output: bool = False,
     ) -> None:
         consistency_map = {
             "ONE": wvc.ConsistencyLevel.ONE,
@@ -481,7 +483,21 @@ class BenchmarkQPSManager(BenchmarkManager):
                 fail_on_timeout=fail_on_timeout,
             )
             if not qps:
-                click.echo(f"\nThe maximum sustainable QPS is approximately {max_qps}.")
+                if json_output:
+                    click.echo(
+                        json.dumps(
+                            {
+                                "status": "success",
+                                "collection": collection,
+                                "max_qps": max_qps,
+                            },
+                            indent=2,
+                        )
+                    )
+                else:
+                    click.echo(
+                        f"\nThe maximum sustainable QPS is approximately {max_qps}."
+                    )
         finally:
             if csv_file:
                 csv_file.close()


### PR DESCRIPTION
This PR adds comprehensive --json flag support to all weaviate-cli commands and creates extensive agent skill documentation for operating and contributing to the CLI. The changes enable programmatic consumption of all command outputs and provide Claude with detailed operational and development guidance.

- Add .claude/skills/operating-weaviate-cli/ with command reference, workflow guides, and configuration patterns for using the CLI against live clusters
- Add .claude/skills/contributing-to-weaviate-cli/ with architecture docs, adding-commands guide, testing patterns, and code review checklist
- Migrate legacy AGENTS.md and commands/ docs into the new skills structure
- Add --json support to all commands missing it (create, delete, update, etc.)
- Add print_json_or_text() utility for consistent JSON/text output
- Add .claude-plugin/plugin.json for skill discovery
- Fix replication_deletion_strategy help text to reflect actual default
- Remove unused term field from CreateBenchmarkDefaults