### PR TITLE
WIP add retries to create data for consistency

### DIFF
--- a/weaviate_cli/commands/create.py
+++ b/weaviate_cli/commands/create.py
@@ -542,6 +542,24 @@ def create_backup_cli(
     help=f"Number of tenants to process in parallel (default: {CreateDataDefaults.parallel_workers}). Set to 1 to disable parallelism.",
 )
 @click.option(
+    "--max_retries",
+    default=CreateDataDefaults.max_retries,
+    type=int,
+    help=f"Maximum number of retries for transient errors like shard not found (default: {CreateDataDefaults.max_retries}).",
+)
+@click.option(
+    "--retry_initial_delay",
+    default=CreateDataDefaults.retry_initial_delay,
+    type=float,
+    help=f"Initial delay between retries in seconds (default: {CreateDataDefaults.retry_initial_delay}).",
+)
+@click.option(
+    "--retry_max_delay",
+    default=CreateDataDefaults.retry_max_delay,
+    type=float,
+    help=f"Maximum delay between retries in seconds (default: {CreateDataDefaults.retry_max_delay}).",
+)
+@click.option(
     "--json", "json_output", is_flag=True, default=False, help="Output in JSON format."
 )
 @click.pass_context
@@ -557,6 +575,9 @@ def create_data_cli(
     tenant_suffix,
     vector_dimensions,
     uuid,
+    max_retries,
+    retry_initial_delay,
+    retry_max_delay,
     wait_for_indexing,
     verbose,
     multi_vector,
@@ -616,6 +637,9 @@ def create_data_cli(
             concurrent_requests=concurrent_requests,
             parallel_workers=parallel_workers,
             json_output=json_output,
+            max_retries=max_retries,
+            retry_initial_delay=retry_initial_delay,
+            retry_max_delay=retry_max_delay,
         )
     except Exception as e:
         click.echo(f"Error: {e}")

--- a/weaviate_cli/defaults.py
+++ b/weaviate_cli/defaults.py
@@ -125,6 +125,9 @@ class CreateDataDefaults:
     batch_size: int = 1000
     dynamic_batch: bool = False
     parallel_workers: int = MAX_WORKERS
+    max_retries: int = 3
+    retry_initial_delay: float = 1.0
+    retry_max_delay: float = 30.0
 
 
 @dataclass

--- a/weaviate_cli/managers/data_manager.py
+++ b/weaviate_cli/managers/data_manager.py
@@ -9,6 +9,7 @@ from collections import deque
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Union, Any, Tuple
+import grpc
 
 import click
 import numpy as np
@@ -29,6 +30,11 @@ from weaviate_cli.defaults import (
     QueryDataDefaults,
     UpdateDataDefaults,
     DeleteDataDefaults,
+)
+
+RETRY_EXCEPTIONS = (
+    grpc.RpcError,
+    Exception,
 )
 from weaviate_cli.utils import pp_objects
 
@@ -659,13 +665,46 @@ class DataManager:
         batch_size: int = 1000,
         concurrent_requests: int = MAX_WORKERS,
         json_output: bool = False,
+        max_retries: int = CreateDataDefaults.max_retries,
+        retry_initial_delay: float = CreateDataDefaults.retry_initial_delay,
+        retry_max_delay: float = CreateDataDefaults.retry_max_delay,
     ) -> Collection:
+        def _is_retryable_error(e: Exception) -> bool:
+            error_str = str(e).lower()
+            retryable_patterns = [
+                "shard not found",
+                "shard unavailable",
+                "temporarily unavailable",
+                "service unavailable",
+                "connection reset",
+                "connection refused",
+                "deadline exceeded",
+                " UNAVAILABLE",
+                " CANCELLED",
+            ]
+            return any(pattern.lower() in error_str for pattern in retryable_patterns)
+
+        def _do_ingest() -> Tuple[int, List, _ErrorTracker]:
+            return self.__producer_consumer_ingest(
+                collection=cl_collection,
+                num_objects=num_objects,
+                vectorizer=vectorizer,
+                vector_dimensions=vector_dimensions or 1536,
+                named_vectors=named_vectors,
+                uuid=uuid,
+                dynamic_batch=dynamic_batch,
+                batch_size=batch_size,
+                concurrent_requests=concurrent_requests,
+                multi_vector=multi_vector,
+                skip_seed=skip_seed,
+                verbose=verbose,
+            )
+
         if randomize:
             if not json_output:
                 click.echo(f"Generating and ingesting {num_objects} objects")
             start_time = time.time()
 
-            # Determine vector dimensions based on vectorizer
             config = collection.config.get()
 
             if not config.vectorizer and config.vector_config:
@@ -682,21 +721,29 @@ class DataManager:
 
             cl_collection = collection.with_consistency_level(cl)
 
-            # Single consumer that feeds the batcher; batcher does its own HTTP parallelism
-            counter, failed_objects, error_tracker = self.__producer_consumer_ingest(
-                collection=cl_collection,
-                num_objects=num_objects,
-                vectorizer=vectorizer,
-                vector_dimensions=vector_dimensions or 1536,
-                named_vectors=named_vectors,
-                uuid=uuid,
-                dynamic_batch=dynamic_batch,
-                batch_size=batch_size,
-                concurrent_requests=concurrent_requests,
-                multi_vector=multi_vector,
-                skip_seed=skip_seed,
-                verbose=verbose,
-            )
+            delay = retry_initial_delay
+            last_error = None
+            for attempt in range(max_retries + 1):
+                try:
+                    counter, _, error_tracker = _do_ingest()
+                    break
+                except Exception as e:
+                    last_error = e
+                    if attempt < max_retries and _is_retryable_error(e):
+                        wait_time = min(delay, retry_max_delay)
+                        if verbose:
+                            click.echo(
+                                f"Retryable error encountered (attempt {attempt + 1}/{max_retries + 1}): {e}. "
+                                f"Retrying in {wait_time:.1f}s...",
+                                err=True,
+                            )
+                        time.sleep(wait_time)
+                        delay *= 2
+                    else:
+                        raise
+
+            if last_error and "counter" not in locals():
+                raise last_error
 
             # New compact failure summary (replaces old block)
             if error_tracker.total > 0:
@@ -828,6 +875,9 @@ class DataManager:
         concurrent_requests: int = MAX_WORKERS,
         parallel_workers: int = CreateDataDefaults.parallel_workers,
         json_output: bool = False,
+        max_retries: int = CreateDataDefaults.max_retries,
+        retry_initial_delay: float = CreateDataDefaults.retry_initial_delay,
+        retry_max_delay: float = CreateDataDefaults.retry_max_delay,
     ) -> Collection:
 
         if not self.client.collections.exists(collection):
@@ -901,6 +951,9 @@ class DataManager:
                     batch_size=batch_size,
                     concurrent_requests=effective_concurrent,
                     json_output=json_output,
+                    max_retries=max_retries,
+                    retry_initial_delay=retry_initial_delay,
+                    retry_max_delay=retry_max_delay,
                 )
                 _after = len(col)
             else:
@@ -937,6 +990,9 @@ class DataManager:
                     batch_size=batch_size,
                     concurrent_requests=effective_concurrent,
                     json_output=json_output,
+                    max_retries=max_retries,
+                    retry_initial_delay=retry_initial_delay,
+                    retry_max_delay=retry_max_delay,
                 )
                 _after = len(col.with_tenant(tenant))
             if wait_for_indexing:


### PR DESCRIPTION
This error shows in some CI jobs https://github.com/weaviate/weaviate-e2e-tests/actions/runs/24739340905/job/72374934517#step:15:651


==================================== ERRORS ====================================
_ ERROR at setup of test_delete_read_repair_http_request[novector_timebasedresolution_class] _

self = <weaviate.connect.v4.ConnectionSync object at 0x7fa8bed27150>
request = collection: "Read_repair_testpy_test_delete_read_repair_http_requestnovector_timebasedresolution_class_2"
tenant: "test-tenant-0"
objects_count: true


    def grpc_aggregate(
        self, request: aggregate_pb2.AggregateRequest
    ) -> aggregate_pb2.AggregateReply:
        try:
            assert self.grpc_stub is not None
>           res = _Retry(4).with_exponential_backoff(
                0,
                f"Searching in collection {request.collection}",
                self.grpc_stub.Aggregate,
                request,
                metadata=self.grpc_headers(),
                timeout=self.timeout_config.query,
            )

/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/weaviate/connect/v4.py:1083: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/weaviate/retry.py:54: in with_exponential_backoff
    raise e
/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/weaviate/retry.py:50: in with_exponential_backoff
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/grpc/_channel.py:1159: in __call__
    return _end_unary_response_blocking(state, call, False, None)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

state = <grpc._channel._RPCState object at 0x7fa8a4635e90>
call = <grpc._cython.cygrpc.SegregatedCall object at 0x7fa8a46365c0>
with_call = False, deadline = None

    def _end_unary_response_blocking(
        state: _RPCState,
        call: cygrpc.SegregatedCall,
        with_call: bool,
        deadline: Optional[float],
    ) -> Union[ResponseType, Tuple[ResponseType, grpc.Call]]:
        if state.code is grpc.StatusCode.OK:
            if with_call:
                rendezvous = _MultiThreadedRendezvous(state, call, None, deadline)
                return state.response, rendezvous
            return state.response
>       raise _InactiveRpcError(state)  # pytype: disable=not-instantiable
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
E       	status = StatusCode.UNKNOWN
E       	details = "aggregate: shard not found"
E       	debug_error_string = "UNKNOWN:Error received from peer  {grpc_status:2, grpc_message:"aggregate: shard not found"}"
E       >

/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/grpc/_channel.py:990: _InactiveRpcError

During handling of the above exception, another exception occurred:

request = <SubRequest 'collection_fixture' for <Function test_delete_read_repair_http_request[novector_timebasedresolution_class]>>

    @pytest.fixture
    def collection_fixture(request):
>       return request.getfixturevalue(request.param)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

tests/recovery/python_recovery/read_repair_test.py:245: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/fixtures.py:539: in getfixturevalue
    fixturedef = self._get_active_fixturedef(argname)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/fixtures.py:627: in _get_active_fixturedef
    fixturedef.execute(request=subrequest)
/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/fixtures.py:1110: in execute
    result: FixtureValue = ihook.pytest_fixture_setup(
/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_hooks.py:512: in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_manager.py:120: in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_callers.py:53: in run_old_style_hookwrapper
    return result.get_result()
           ^^^^^^^^^^^^^^^^^^^
/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_callers.py:38: in run_old_style_hookwrapper
    res = yield
          ^^^^^
/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/setuponly.py:36: in pytest_fixture_setup
    return (yield)
            ^^^^^
/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/fixtures.py:1202: in pytest_fixture_setup
    result = call_fixture_func(fixturefunc, request, kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/fixtures.py:908: in call_fixture_func
    fixture_result = next(generator)
                     ^^^^^^^^^^^^^^^
tests/recovery/python_recovery/read_repair_test.py:148: in novector_timebasedresolution_class
    collection = _create_base_collection(
tests/recovery/python_recovery/read_repair_test.py:98: in _create_base_collection
    DataManager(client).create_data(
/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/weaviate_cli/managers/data_manager.py:978: in create_data
    inserted, collection = _ingest_one_tenant(tenant)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^
/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/weaviate_cli/managers/data_manager.py:923: in _ingest_one_tenant
    _initial = len(col.with_tenant(tenant))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/weaviate/collections/collection/sync.py:148: in __len__
    total = self.aggregate.over_all(total_count=True).total_count
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/weaviate/collections/aggregations/over_all/executor.py:115: in over_all
    return executor.execute(
/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/weaviate/connect/executor.py:99: in execute
    return cast(T, exception_callback(e))
                   ^^^^^^^^^^^^^^^^^^^^^
/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/weaviate/connect/executor.py:38: in raise_exception
    raise e
/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/weaviate/connect/executor.py:80: in execute
    call = method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <weaviate.connect.v4.ConnectionSync object at 0x7fa8bed27150>
request = collection: "Read_repair_testpy_test_delete_read_repair_http_requestnovector_timebasedresolution_class_2"
tenant: "test-tenant-0"
objects_count: true


    def grpc_aggregate(
        self, request: aggregate_pb2.AggregateRequest
    ) -> aggregate_pb2.AggregateReply:
        try:
            assert self.grpc_stub is not None
            res = _Retry(4).with_exponential_backoff(
                0,
                f"Searching in collection {request.collection}",
                self.grpc_stub.Aggregate,
                request,
                metadata=self.grpc_headers(),
                timeout=self.timeout_config.query,
            )
            return cast(aggregate_pb2.AggregateReply, res)
        except RpcError as e:
            error = cast(Call, e)
            if error.code() == StatusCode.PERMISSION_DENIED:
                raise InsufficientPermissionsError(error)
>           raise WeaviateQueryError(str(e), "GRPC search")  # pyright: ignore
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           weaviate.exceptions.WeaviateQueryError: Query call with protocol GRPC search failed with message <_InactiveRpcError of RPC that terminated with:
E           	status = StatusCode.UNKNOWN
E           	details = "aggregate: shard not found"
E           	debug_error_string = "UNKNOWN:Error received from peer  {grpc_status:2, grpc_message:"aggregate: shard not found"}"
E           >.

/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/weaviate/connect/v4.py:1096: WeaviateQueryError


I believe there is a race in create_data when auto tenant creation is on, as the producer-consumer task queue can have either a stale tenant list or a tenant list with tenants that have not propogated yet.