### PR TITLE
chore: weaviate cli and python version increases

### DIFF
--- a/.claude/skills/operating-weaviate-cli/SKILL.md
+++ b/.claude/skills/operating-weaviate-cli/SKILL.md
@@ -148,17 +148,19 @@ Mutable fields: `--async_enabled`, `--replication_factor`, `--vector_index`, `--
 ```bash
 # Create with async replication tuning (requires --async_enabled and Weaviate >= v1.36.0)
 weaviate-cli create collection --collection MyCol --async_enabled \
-  --async_replication_config max_workers=10 \
   --async_replication_config frequency=60 \
+  --async_replication_config hashtree_height=16 \
   --async_replication_config propagation_concurrency=4 --json
 
 # Update async replication config on existing collection
 weaviate-cli update collection --collection MyCol \
-  --async_replication_config max_workers=20 \
+  --async_replication_config propagation_delay=30 \
   --async_replication_config propagation_batch_size=100 --json
 ```
 
 Valid keys (all integers): `max_workers`, `hashtree_height`, `frequency`, `frequency_while_propagating`, `alive_nodes_checking_frequency`, `logging_frequency`, `diff_batch_size`, `diff_per_node_timeout`, `pre_propagation_timeout`, `propagation_timeout`, `propagation_limit`, `propagation_delay`, `propagation_concurrency`, `propagation_batch_size`
+
+Deprecated (removed from the server schema in Weaviate v1.37.3 and silently ignored from that version on, but still accepted for older servers): `max_workers`, `alive_nodes_checking_frequency`.
 
 #### Object TTL
 

--- a/.claude/skills/operating-weaviate-cli/references/collections.md
+++ b/.claude/skills/operating-weaviate-cli/references/collections.md
@@ -48,7 +48,7 @@ weaviate-cli create collection \
 - `--hfresh_search_probe` -- (hfresh only) Search probe size (default: None, uses server default)
 - `--distance_metric` -- Distance metric: cosine, dot, l2-squared, hamming, manhattan (default: None, uses server default). Applies to all vector index types.
 - `--rescore_limit` -- Rescore limit for quantized indexes (default: None, uses server default)
-- `--async_replication_config` -- Async replication tuning as `key=value` pairs (repeatable). Valid keys: `max_workers`, `hashtree_height`, `frequency`, `frequency_while_propagating`, `alive_nodes_checking_frequency`, `logging_frequency`, `diff_batch_size`, `diff_per_node_timeout`, `pre_propagation_timeout`, `propagation_timeout`, `propagation_limit`, `propagation_delay`, `propagation_concurrency`, `propagation_batch_size`. All values must be integers. Use `reset` to revert all to server defaults. Requires `--async_enabled` on create and Weaviate >= v1.36.0.
+- `--async_replication_config` -- Async replication tuning as `key=value` pairs (repeatable). Valid keys: `max_workers`, `hashtree_height`, `frequency`, `frequency_while_propagating`, `alive_nodes_checking_frequency`, `logging_frequency`, `diff_batch_size`, `diff_per_node_timeout`, `pre_propagation_timeout`, `propagation_timeout`, `propagation_limit`, `propagation_delay`, `propagation_concurrency`, `propagation_batch_size`. All values must be integers. Use `reset` to revert all to server defaults. Requires `--async_enabled` on create and Weaviate >= v1.36.0. Deprecated (removed from the server schema in Weaviate v1.37.3 and silently ignored from that version on, but still accepted for older servers): `max_workers`, `alive_nodes_checking_frequency`.
 
 **hfresh examples:**
 ```bash
@@ -71,8 +71,8 @@ weaviate-cli create collection \
 ```bash
 # Create with custom async replication tuning
 weaviate-cli create collection --collection MyCol --async_enabled \
-  --async_replication_config max_workers=10 \
   --async_replication_config frequency=60 \
+  --async_replication_config hashtree_height=16 \
   --async_replication_config propagation_concurrency=4
 
 # Set a single parameter
@@ -112,7 +112,7 @@ Mutable fields: `--async_enabled`, `--replication_factor`, `--vector_index`, `--
 ```bash
 # Update async replication tuning on existing collection
 weaviate-cli update collection --collection MyCol \
-  --async_replication_config max_workers=20 \
+  --async_replication_config propagation_delay=30 \
   --async_replication_config propagation_batch_size=100
 ```
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-weaviate-client>=4.21.0
+weaviate-client>=4.23.0
 click==8.1.7
 twine
 pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,17 +27,17 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
 
 [options]
 include_package_data = True
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires =
-    weaviate-client>=4.21.0
+    weaviate-client>=4.23.0
     click==8.1.7
     semver>=3.0.2
     numpy>=1.24.0

--- a/test/unittests/test_managers/test_collection_manager.py
+++ b/test/unittests/test_managers/test_collection_manager.py
@@ -1114,3 +1114,114 @@ def test_update_collection_async_replication_config_warns_on_old_version(
         captured.out + captured.err
     )
     mock_collection.config.update.assert_called_once()
+
+
+def test_create_collection_warns_on_removed_async_replication_keys(
+    mock_client, mock_wvc_object_ttl, capsys
+):
+    """Warn when a removed async replication key is used against a server >= v1.37.3."""
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_collections.exists.side_effect = [False, True]
+    mock_client.get_meta.return_value = {"version": "1.38.0"}
+
+    manager = CollectionManager(mock_client)
+
+    manager.create_collection(
+        collection="TestCollection",
+        replication_factor=3,
+        vector_index="hnsw",
+        async_enabled=True,
+        async_replication_config={"max_workers": 10, "frequency": 60},
+    )
+
+    captured = capsys.readouterr()
+    assert "max_workers removed from the Weaviate server schema in v1.37.3" in (
+        captured.out + captured.err
+    )
+    mock_collections.create.assert_called_once()
+
+
+def test_create_collection_no_removed_key_warning_on_older_server(
+    mock_client, mock_wvc_object_ttl, capsys
+):
+    """A server older than v1.37.3 still supports the key, so no warning is emitted."""
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_collections.exists.side_effect = [False, True]
+    mock_client.get_meta.return_value = {"version": "1.36.0"}
+
+    manager = CollectionManager(mock_client)
+
+    manager.create_collection(
+        collection="TestCollection",
+        replication_factor=3,
+        vector_index="hnsw",
+        async_enabled=True,
+        async_replication_config={"max_workers": 10},
+    )
+
+    captured = capsys.readouterr()
+    assert "removed from the Weaviate server schema" not in (
+        captured.out + captured.err
+    )
+    mock_collections.create.assert_called_once()
+
+
+def test_create_collection_no_removed_key_warning_for_supported_keys(
+    mock_client, mock_wvc_object_ttl, capsys
+):
+    """Keys that are still supported never trigger the removal warning."""
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_collections.exists.side_effect = [False, True]
+    mock_client.get_meta.return_value = {"version": "1.38.0"}
+
+    manager = CollectionManager(mock_client)
+
+    manager.create_collection(
+        collection="TestCollection",
+        replication_factor=3,
+        vector_index="hnsw",
+        async_enabled=True,
+        async_replication_config={"frequency": 60},
+    )
+
+    captured = capsys.readouterr()
+    assert "removed from the Weaviate server schema" not in (
+        captured.out + captured.err
+    )
+    mock_collections.create.assert_called_once()
+
+
+def test_update_collection_warns_on_removed_async_replication_keys(
+    mock_client, mock_wvc_object_ttl, capsys
+):
+    """Warn when a removed async replication key is used against a server >= v1.37.3."""
+    mock_collections = MagicMock()
+    mock_client.collections = mock_collections
+    mock_client.collections.exists.side_effect = [True, True]
+    mock_client.get_meta.return_value = {"version": "1.38.0"}
+
+    mock_collection = MagicMock()
+    mock_client.collections.get.return_value = mock_collection
+    mock_collection.config.get.return_value = MagicMock(
+        replication_config=MagicMock(factor=3),
+        multi_tenancy_config=MagicMock(
+            enabled=False, auto_tenant_creation=False, auto_tenant_activation=False
+        ),
+    )
+
+    manager = CollectionManager(mock_client)
+
+    manager.update_collection(
+        collection="TestCollection",
+        async_replication_config={"alive_nodes_checking_frequency": 30},
+    )
+
+    captured = capsys.readouterr()
+    assert (
+        "alive_nodes_checking_frequency removed from the Weaviate server schema "
+        "in v1.37.3"
+    ) in (captured.out + captured.err)
+    mock_collection.config.update.assert_called_once()

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -6,6 +6,10 @@ from weaviate_cli.utils import (
     pp_objects,
     parse_permission,
     parse_async_replication_config,
+    warn_removed_async_replication_keys,
+    ASYNC_REPLICATION_CONFIG_DEPRECATED_KEYS,
+    ASYNC_REPLICATION_CONFIG_KEYS,
+    ASYNC_REPLICATION_CONFIG_HELP,
 )
 from weaviate.collections import Collection
 from io import StringIO
@@ -461,3 +465,73 @@ def test_parse_async_replication_config_reset_case_insensitive():
 def test_parse_async_replication_config_reset_with_other_keys():
     with pytest.raises(ValueError, match="Expected key=value"):
         parse_async_replication_config(("reset", "max_workers=10"))
+
+
+def test_deprecated_async_replication_keys_still_accepted():
+    """Deprecated keys must keep parsing, so older servers are not broken."""
+    for key in ASYNC_REPLICATION_CONFIG_DEPRECATED_KEYS:
+        assert key in ASYNC_REPLICATION_CONFIG_KEYS
+        assert parse_async_replication_config((f"{key}=10",)) == {key: 10}
+
+
+def test_async_replication_help_flags_deprecated_keys():
+    assert "Deprecated keys, ignored by Weaviate >= v1.37.3" in (
+        ASYNC_REPLICATION_CONFIG_HELP
+    )
+    for key in ASYNC_REPLICATION_CONFIG_DEPRECATED_KEYS:
+        assert key in ASYNC_REPLICATION_CONFIG_HELP
+
+
+def test_warn_removed_async_replication_keys_on_new_server(capsys):
+    client = MagicMock()
+    client.get_meta.return_value = {"version": "1.37.3"}
+
+    warn_removed_async_replication_keys(client, {"max_workers": 10})
+
+    captured = capsys.readouterr()
+    assert "max_workers removed from the Weaviate server schema in v1.37.3" in (
+        captured.out + captured.err
+    )
+
+
+def test_warn_removed_async_replication_keys_lists_all_removed_keys(capsys):
+    client = MagicMock()
+    client.get_meta.return_value = {"version": "1.38.0"}
+
+    warn_removed_async_replication_keys(
+        client, {"max_workers": 10, "alive_nodes_checking_frequency": 30}
+    )
+
+    captured = capsys.readouterr()
+    assert "alive_nodes_checking_frequency, max_workers removed" in (
+        captured.out + captured.err
+    )
+
+
+def test_warn_removed_async_replication_keys_silent_on_old_server(capsys):
+    client = MagicMock()
+    client.get_meta.return_value = {"version": "1.37.2"}
+
+    warn_removed_async_replication_keys(client, {"max_workers": 10})
+
+    assert capsys.readouterr().out == ""
+
+
+def test_warn_removed_async_replication_keys_silent_for_supported_keys(capsys):
+    client = MagicMock()
+    client.get_meta.return_value = {"version": "1.38.0"}
+
+    warn_removed_async_replication_keys(client, {"frequency": 60})
+
+    assert capsys.readouterr().out == ""
+
+
+def test_warn_removed_async_replication_keys_handles_empty_config(capsys):
+    """None (unset) and {} (reset) must not trigger a server version lookup."""
+    client = MagicMock()
+
+    warn_removed_async_replication_keys(client, None)
+    warn_removed_async_replication_keys(client, {})
+
+    client.get_meta.assert_not_called()
+    assert capsys.readouterr().out == ""

--- a/weaviate_cli/managers/collection_manager.py
+++ b/weaviate_cli/managers/collection_manager.py
@@ -12,7 +12,11 @@ from weaviate_cli.defaults import (
     DeleteCollectionDefaults,
     GetCollectionDefaults,
 )
-from weaviate_cli.utils import print_json_or_text, older_than_version
+from weaviate_cli.utils import (
+    print_json_or_text,
+    older_than_version,
+    warn_removed_async_replication_keys,
+)
 import weaviate.classes.config as wvc
 from prettytable import PrettyTable
 
@@ -263,6 +267,8 @@ class CollectionManager:
                 "Warning: --async_replication_config requires Weaviate >= v1.36.0. "
                 "The server may ignore or reject these settings."
             )
+
+        warn_removed_async_replication_keys(self.client, async_replication_config)
 
         if named_vector_name != "default" and not named_vector:
             raise Exception(
@@ -678,6 +684,8 @@ class CollectionManager:
                 "Warning: --async_replication_config requires Weaviate >= v1.36.0. "
                 "The server may ignore or reject these settings."
             )
+
+        warn_removed_async_replication_keys(self.client, async_replication_config)
 
         if not self.client.collections.exists(collection):
 

--- a/weaviate_cli/utils.py
+++ b/weaviate_cli/utils.py
@@ -134,6 +134,15 @@ ASYNC_REPLICATION_CONFIG_KEYS = {
 }
 
 
+# Removed from the Weaviate server schema in v1.37.3. Still accepted by the CLI so
+# that users targeting older servers are not broken, but ignored by newer servers.
+ASYNC_REPLICATION_CONFIG_DEPRECATED_KEYS = {
+    "max_workers",
+    "alive_nodes_checking_frequency",
+}
+
+ASYNC_REPLICATION_CONFIG_REMOVED_VERSION = "1.37.3"
+
 ASYNC_REPLICATION_CONFIG_RESET = "reset"
 
 ASYNC_REPLICATION_CONFIG_HELP = (
@@ -141,7 +150,12 @@ ASYNC_REPLICATION_CONFIG_HELP = (
     "Valid keys: " + ", ".join(sorted(ASYNC_REPLICATION_CONFIG_KEYS)) + ". "
     "All values must be integers. "
     'Use "reset" to revert all async replication settings to server defaults (update only). '
-    "Requires --async_enabled on create and Weaviate >= v1.36.0."
+    "Requires --async_enabled on create and Weaviate >= v1.36.0. "
+    "Deprecated keys, ignored by Weaviate >= v"
+    + ASYNC_REPLICATION_CONFIG_REMOVED_VERSION
+    + ": "
+    + ", ".join(sorted(ASYNC_REPLICATION_CONFIG_DEPRECATED_KEYS))
+    + "."
 )
 
 
@@ -194,6 +208,33 @@ def parse_async_replication_config(
             )
 
     return result
+
+
+def warn_removed_async_replication_keys(
+    client, async_replication_config: Optional[dict]
+) -> None:
+    """Warn when async replication keys the target server no longer supports are used.
+
+    ``max_workers`` and ``alive_nodes_checking_frequency`` were removed from the
+    Weaviate server schema in v1.37.3 and are silently ignored from that version on.
+    They remain accepted here so that users targeting older servers keep working.
+    """
+    if not async_replication_config:
+        return
+
+    removed = sorted(
+        ASYNC_REPLICATION_CONFIG_DEPRECATED_KEYS & set(async_replication_config)
+    )
+    if not removed or older_than_version(
+        client, ASYNC_REPLICATION_CONFIG_REMOVED_VERSION
+    ):
+        return
+
+    click.echo(
+        f"Warning: {', '.join(removed)} removed from the Weaviate server schema in "
+        f"v{ASYNC_REPLICATION_CONFIG_REMOVED_VERSION}. "
+        "This server will ignore these settings."
+    )
 
 
 def parse_permission(perm: str) -> PermissionsCreateType:


### PR DESCRIPTION
## Summary

- Bump `weaviate-client` `>=4.21.0` -> `>=4.23.0`. Older clients raise `ValueError: 'INTEGRATING' is not a valid ReplicateOperationState`, breaking `get`/`query replications`
- `python_requires` `>=3.9` -> `>=3.10`, drop 3.9 classifier, add 3.13. The client has required 3.10+ since 4.21.0, so 3.9 already could not install
- Mark `max_workers` and `alive_nodes_checking_frequency` deprecated — removed server-side in v1.37.3. Still parsed and sent, so older servers are unaffected; warns only on v1.37.3+
- Update `--help` and skill docs, which led with the deprecated `max_workers` in every example
- Add 11 unit tests
